### PR TITLE
Vampire code unerroration

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -52,6 +52,7 @@
 
 	var/datum/faction/faction 			//associated faction
 	var/datum/changeling/changeling		//changeling holder
+	var/datum/vampire/vampire			//vamp holder; really have to clean this up someday.
 
 	var/rev_cooldown = 0
 
@@ -143,7 +144,7 @@
 
 	if(href_list["add_antagonist"])
 		var/datum/antagonist/antag = all_antag_types[href_list["add_antagonist"]]
-		if(antag) 
+		if(antag)
 			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
 				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
 			else

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -44,6 +44,7 @@
 	var/default_access = list()
 	var/id_type = /obj/item/weapon/card/id
 	var/announced
+	var/uristantag = 0 //used for overriding the indicator icon path to our own dmi
 
 /datum/antagonist/New()
 	..()
@@ -59,7 +60,7 @@
 
 /datum/antagonist/proc/get_candidates(var/ghosts_only)
 	candidates = list() // Clear.
-	
+
 	// Prune restricted status. Broke it up for readability.
 	// Note that this is done before jobs are handed out.
 	for(var/datum/mind/player in ticker.mode.get_players_for_role(role_type, id))
@@ -126,14 +127,14 @@
 		return 0
 
 	pending_antagonists |= player
-	
+
 	//Ensure that antags with ANTAG_OVERRIDE_JOB do not occupy job slots.
 	if(flags & ANTAG_OVERRIDE_JOB)
 		player.assigned_role = role_text
-	
+
 	//Ensure that a player cannot be drafted for multiple antag roles, taking up slots for antag roles that they will not fill.
 	player.special_role = role_text
-	
+
 	return 1
 
 //Spawns all pending_antagonists. This is done separately from attempt_spawn in case the game mode setup fails.

--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -32,7 +32,10 @@
 					qdel(I)
 			for(var/datum/mind/other_antag in current_antagonists)
 				if(other_antag.current)
-					antag.current.client.images |= image('icons/mob/mob.dmi', loc = other_antag.current, icon_state = antag_indicator)
+					if(uristantag)
+						antag.current.client.images |= image('icons/urist/uristicons.dmi', loc = other_antag.current, icon_state = antag_indicator)
+					else
+						antag.current.client.images |= image('icons/mob/mob.dmi', loc = other_antag.current, icon_state = antag_indicator)
 
 /datum/antagonist/proc/update_icons_added(var/datum/mind/player)
 	if(!antag_indicator || !player.current)
@@ -41,10 +44,16 @@
 		for(var/datum/mind/antag in current_antagonists)
 			if(!antag.current)
 				continue
-			if(antag.current.client)
-				antag.current.client.images |= image('icons/mob/mob.dmi', loc = player.current, icon_state = antag_indicator)
-			if(player.current.client)
-				player.current.client.images |= image('icons/mob/mob.dmi', loc = antag.current, icon_state = antag_indicator)
+			if(uristantag)
+				if(antag.current.client)
+					antag.current.client.images |= image('icons/urist/uristicons.dmi', loc = player.current, icon_state = antag_indicator)
+				if(player.current.client)
+					player.current.client.images |= image('icons/urist/uristicons.dmi', loc = antag.current, icon_state = antag_indicator)
+			else
+				if(antag.current.client)
+					antag.current.client.images |= image('icons/mob/mob.dmi', loc = player.current, icon_state = antag_indicator)
+				if(player.current.client)
+					player.current.client.images |= image('icons/mob/mob.dmi', loc = antag.current, icon_state = antag_indicator)
 
 /datum/antagonist/proc/update_icons_removed(var/datum/mind/player)
 	if(!antag_indicator || !player.current)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -376,6 +376,7 @@
 		if(status_flags & GODMODE)
 			return
 
+
 		if(!breath || (breath.total_moles == 0) || suiciding)
 			failed_last_breath = 1
 			if(suiciding)
@@ -1016,34 +1017,6 @@
 				if( prob(2) && health && !hal_crit )
 					spawn(0)
 						emote("snore")
-
-				if(mind)
-					if(mind.vampire) //VAMP COFFIN REGEN CODE BEGINS
-						if(istype(loc, /obj/structure/closet/coffin))
-							var/mob/living/carbon/human/H = mind.current
-							H.adjustBruteLoss(-2)
-							H.adjustFireLoss(-2)
-							H.adjustToxLoss(-2)
-							H.adjustOxyLoss(-2)
-							H.shock_stage -= 5
-							if(prob(15))
-								H << "<span class='notice'>You can feel the bones and organs in your body shift, mend and regrow!"
-								for(var/datum/organ/internal/I in H.internal_organs)
-									I.damage = 0
-								for (var/datum/organ/external/E in H.organs)
-									if(E.status & ORGAN_ROBOT)
-										if(E.status & ~ORGAN_DESTROYED)	//Robotic organs stay robotic, but only if they are still there. Otherwise, regrow a normal limb.
-											E.status = ORGAN_ROBOT
-										else
-											E.status = 0
-									else
-										E.status = 0
-									E.perma_injury = 0
-									E.brute_dam -= 35 //this line and the next were added to prevent autorebreaks due to excessive damage
-									E.burn_dam -= 35 //comment out or lower if it proves too powerful
-									E.number_wounds = 0
-									E.germ_level = 0
-								H.update_body(1)
 
 			else if(resting)
 				if(halloss > 0)

--- a/code/modules/urist/antagonist/vampire.dm
+++ b/code/modules/urist/antagonist/vampire.dm
@@ -1,19 +1,41 @@
+/datum/antagonist/thrall
+	id = "thrall"
+	role_text = "Thrall"
+	role_text_plural = "Thralls"
+	restricted_jobs = list("AI", "Cyborg", "Chaplain")
+	protected_jobs = list() //not applicable
+	welcome_text = "You have become a vampire's thrall. Follow their every command."
+	flags = 0
+	antag_indicator = null
+	uristantag = 1
+	var/datum/mind/master = null
+
+
+/datum/antagonist/thrall/add_antagonist(var/datum/mind/player, var/datum/mind/master)
+	if(!can_become_antag(player))
+		return 0
+	current_antagonists |= player
+	player.special_role = "Thrall"
+	update_icons_added(player)
+
 /datum/antagonist/vampire
 	id = MODE_VAMPIRE
 	role_type = BE_VAMPIRE
-	role_text = "vampire"
-	role_text_plural = "vampires"
+	role_text = "Vampire"
+	role_text_plural = "Vampires"
 	bantype = "vampire"
 	feedback_tag = "vampire_objective"
 	restricted_jobs = list("AI", "Cyborg", "Chaplain")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
-	welcome_text = "You are a Vampire! To bite someone, target the head and use harm intent with an empty hand. Drink blood to gain new powers. You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel and especially Holy Water."
+	welcome_text = "To bite someone, target the head and use harm intent with an empty hand. Drink blood to gain new powers. <br>You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel and, especially, Holy Water."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
+	antag_indicator = "vampire"
+	uristantag = 1
 
-/datum/antagonist/vampire/get_special_objective_text(var/datum/mind/player)
-	return "<br><b>vampire ID:</b> [player.vampire.vampireID].<br><b>Blood Consumed:</b> [player.vampire.bloodtotal]"
+///datum/antagonist/vampire/get_special_objective_text(var/datum/mind/player)
+//	return //"<br><b>Real Name:</b> [player.real_name].
 
-/datum/antagonist/vampire/apply(var/datum/mind/player)
+/datum/antagonist/vampire/update_antag_mob(var/datum/mind/player)
 	..()
 	player.current.make_vampire()
 
@@ -21,7 +43,7 @@
 	if(!..())
 		return
 
-	var/datum/objective/absorb/blood_objective = new
+	var/datum/objective/blood/blood_objective = new
 	blood_objective.owner = vampire
 	blood_objective.gen_amount_goal(150, 400)
 	vampire.objectives += blood_objective
@@ -48,3 +70,22 @@
 				survive_objective.owner = vampire
 				vampire.objectives += survive_objective
 	return
+
+
+/*/datum/game_mode/proc/auto_declare_completion_enthralled()
+	if(enthralled.len)
+		var/text = "<FONT size = 2><B>The Enthralled were:</B></FONT>"
+		for(var/datum/mind/Mind in enthralled)
+			text += "<br>[Mind.key] was [Mind.name] ("
+			if(Mind.current)
+				if(Mind.current.stat == DEAD)
+					text += "died"
+				else
+					text += "survived"
+				if(Mind.current.real_name != Mind.name)
+					text += " as [Mind.current.real_name]"
+			else
+				text += "body destroyed"
+			text += ")"
+		world << text
+	return 1*/

--- a/code/modules/urist/gamemodes/vampire/vampire.dm
+++ b/code/modules/urist/gamemodes/vampire/vampire.dm
@@ -6,10 +6,8 @@ var/global/list/datum/mind/enthralled_list = list() //those controlled by a vamp
 var/global/list/thrallslist = list() //vampires controlling somebody
 
 /datum/game_mode/vampire
-//	id = MODE_VAMPIRE
-	role_type = BE_VAMPIRE
-	role_text = "Vampire"
-	role_text_plural = "Vampires"
+	antag_tag = MODE_VAMPIRE
+	name = "Vampire"
 	round_description = "There are Vampires from Space Transylvania on the station, keep your blood close and neck safe!"
 	extended_round_description = "WIP."
 	config_tag = "vampire"
@@ -17,110 +15,7 @@ var/global/list/thrallslist = list() //vampires controlling somebody
 	required_players_secret = 7
 	required_enemies = 1
 	end_on_antag_death = 1
-	antag_scaling_coeff = 7.5
-
-var/datum/antagonist/vampire/vampires
-var/datum/antagonist/thrall/thralls
-
-/datum/antagonist/thrall
-	id = "thrall"
-	role_text = "Thrall"
-	role_text_plural = "Thralls"
-	restricted_jobs = list("AI", "Cyborg", "Chaplain")
-	protected_jobs = list() //not applicable
-	welcome_text = "You have become a vampire's thrall. Follow their every command."
-	flags = 0
-	antag_indicator = "vampthrall"
-	uristantag = 1
-
-/datum/antagonist/thrall/New()
-	..()
-	thralls = src
-
-/datum/antagonist/thrall/add_antagonist(var/datum/mind/player)
-	if(!can_become_antag(player))
-		return 0
-	current_antagonists |= player
-	player.special_role = "Thrall"
-	update_icons_added(player)
-
-/*/datum/antagonist/vampire
-	id = MODE_VAMPIRE
-	role_type = BE_VAMPIRE
-	role_text = "Vampire"
-	role_text_plural = "Vampires"
-	bantype = "vampire"
-	feedback_tag = "vampire_objective"
-	restricted_jobs = list("AI", "Cyborg", "Chaplain")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
-	welcome_text = "To bite someone, target the head and use harm intent with an empty hand. Drink blood to gain new powers. <br>You are weak to holy things and starlight. Don't go into space and avoid the Chaplain, the chapel and, especially, Holy Water."
-	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
-	antag_indicator = "vampire"
-	uristantag = 1*/
-
-/datum/antagonist/vampire/New()
-	..()
-	vampires = src
-
-///datum/antagonist/vampire/get_special_objective_text(var/datum/mind/player)
-//	return //"<br><b>Real Name:</b> [player.real_name].
-
-/datum/antagonist/vampire/create_objectives(var/datum/mind/vampire)
-	if(!..())
-		return
-
-	var/datum/objective/blood/blood_objective = new
-	blood_objective.owner = vampire
-	blood_objective.gen_amount_goal(150, 400)
-	vampire.objectives += blood_objective
-
-	var/datum/objective/assassinate/kill_objective = new
-	kill_objective.owner = vampire
-	kill_objective.find_target()
-	vampire.objectives += kill_objective
-
-	var/datum/objective/steal/steal_objective = new
-	steal_objective.owner = vampire
-	steal_objective.find_target()
-	vampire.objectives += steal_objective
-
-	switch(rand(1,100))
-		if(1 to 80)
-			if (!(locate(/datum/objective/escape) in vampire.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = vampire
-				vampire.objectives += escape_objective
-		else
-			if (!(locate(/datum/objective/survive) in vampire.objectives))
-				var/datum/objective/survive/survive_objective = new
-				survive_objective.owner = vampire
-				vampire.objectives += survive_objective
-	return
-
-
-/*/datum/game_mode/proc/auto_declare_completion_enthralled()
-	if(enthralled.len)
-		var/text = "<FONT size = 2><B>The Enthralled were:</B></FONT>"
-		for(var/datum/mind/Mind in enthralled)
-			text += "<br>[Mind.key] was [Mind.name] ("
-			if(Mind.current)
-				if(Mind.current.stat == DEAD)
-					text += "died"
-				else
-					text += "survived"
-				if(Mind.current.real_name != Mind.name)
-					text += " as [Mind.current.real_name]"
-			else
-				text += "body destroyed"
-			text += ")"
-		world << text
-	return 1*/
-
-
-
-/datum/game_mode/proc/grant_vampire_powers(mob/living/carbon/vampire_mob)
-	if(!istype(vampire_mob))	return
-	vampire_mob.make_vampire()
+	antag_scaling_coeff = 7
 
 /datum/vampire
 	var/bloodtotal = 0
@@ -140,6 +35,7 @@ var/datum/antagonist/thrall/thralls
 		mind.vampire = new /datum/vampire(gender)
 		mind.vampire.owner = src
 	verbs += /client/proc/vampire_rejuvinate
+	verbs += /client/proc/vampire_coffinsleep
 	verbs += /client/proc/vampire_hypnotise
 	verbs += /client/proc/vampire_glare
 	faction = "vampire"
@@ -200,7 +96,7 @@ var/datum/antagonist/thrall/thralls
 	else
 		H.LAssailant = src
 	while(do_mob(src, H, 50))
-		if((!mind.vampire) || !(mind in vampires))
+		if((!mind.vampire) || !(mind in get_antags("vampire")))
 			src << "<span class='warning'> Your fangs have disappeared!</span>"
 			return 0
 		if(H.flags & NO_BLOOD)
@@ -311,8 +207,9 @@ var/datum/antagonist/thrall/thralls
 					src << "<span class='notice'> You have reached your full potential and are no longer weak to the effects of anything holy and your vision has been improved greatly.</span>"
 					//no verb
 
-/datum/game_mode/proc/update_vampire_icons_removed(datum/mind/vampire_mind)
-	for(var/headref in thralls)
+/datum/game_mode/proc/update_vampire_icons_removed(datum/mind/vampire_mind) //vampporttodo
+	src << "TODO!!!"
+/*	for(var/headref in thralls)
 		var/datum/mind/head = locate(headref)
 		for(var/datum/mind/t_mind in thralls[headref])
 			if(t_mind.current)
@@ -333,18 +230,20 @@ var/datum/antagonist/thrall/thralls
 		if(vampire_mind.current.client)
 			for(var/image/I in vampire_mind.current.client.images)
 				if(I.icon_state == "vampthrall" || I.icon_state == "vampire")
-					del(I)
+					del(I)*/
 
-/datum/game_mode/proc/remove_vampire_mind(datum/mind/vampire_mind, datum/mind/head)
+/datum/game_mode/proc/remove_vampire_mind(datum/mind/vampire_mind, datum/mind/head) //vampporttodo
+	/*
 	if(!istype(head))
 		head = vampire_mind //workaround for removing a thrall's control over the enthralled
 	var/ref = "\ref[head]"
-	if(ref in thralls)
+	if(ref in get_antags("thrall")
 		thralls[ref] -= vampire_mind
-	enthralled -= vampire_mind
+	enthralled_list -= vampire_mind
 	vampire_mind.special_role = null
 	update_vampire_icons_removed(vampire_mind)
 	//world << "Removed [vampire_mind.current.name] from vampire shit"
+	*/
 	vampire_mind.current << "<span class='warning'> <FONT size = 3><B>The fog clouding your mind clears. You remember nothing from the moment you were enthralled until now.</B></FONT></span>"
 
 /mob/living/carbon/human/proc/check_sun()


### PR DESCRIPTION
Cleans up the compiletimes from Vampire code, porting is still WIP since some problematic straggler procs are still yet to be put under the generic antag handling code, but are commented out for sake of vamp-free error logging for you.

Also turns coffinsleep from an ugly hook in life.dm into a 'power' that is an unholy fusion of xenomorph regen code and ling fakedeath and can be woken up from at will, but it will inflict brief drowsiness. Or, indeed, stay in it however long it takes to regenerate. Or to freak out the doctors as they declare you to be a corpse.
