### PR TITLE
Fixes for Baymerge again

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -6,7 +6,7 @@ GLOBAL_TYPED_NEW(changelings, /datum/antagonist/changeling)
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
-	protected_jobs = list(/datum/job/warden, /datum/job/captain, /datum/job/hos)
+	restricted_jobs = list(/datum/job/warden, /datum/job/captain, /datum/job/hos)
 	welcome_text = "Use say \"%LANGUAGE_PREFIX%g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -31,7 +31,7 @@ GLOBAL_TYPED_NEW(revs, /datum/antagonist/revolutionary)
 
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
 	restricted_jobs = list(/datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo, /datum/job/lawyer)
-	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/blueshield)
+	restricted_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective, /datum/job/blueshield)
 
 
 /datum/antagonist/revolutionary/create_global_objectives()

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -181,7 +181,7 @@
 	. = ..()
 
 /obj/landmark/costume/maid/Initialize()
-	new /obj/item/clothing/under/blackskirt(src.loc)
+	new /obj/item/clothing/under/skirt(src.loc)
 	var/CHOICE = pick( /obj/item/clothing/head/beret , /obj/item/clothing/head/rabbitears )
 	new CHOICE(src.loc)
 	new /obj/item/clothing/glasses/blindfold(src.loc)

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -220,7 +220,7 @@
 	max_w_class = ITEM_SIZE_HUGE
 	anchored = TRUE
 	density = FALSE
-	cant_hold = list(/obj/item/storage/secure/briefcase)
+	contents_banned = list(/obj/item/storage/secure/briefcase)
 	startswith = list(
 	/obj/item/gun/energy/taser = 1,
 	/obj/item/gun/projectile/revolver/hi2521r = 1,

--- a/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
+++ b/code/modules/urist/antagonist/revenant/archetypes/chimera.dm
@@ -47,7 +47,7 @@
 	set category = "Anomalous Powers"
 	set desc = "*Painfully* fleshcraft your arm into a vicious blade. Reality won't like this one bit."
 
-	if(bsrevenant_generic_weapon(/obj/item/melee/arm_blade))
+	if(bsrevenant_generic_weapon(/obj/item/melee/changeling/arm_blade))
 		return
 
 	return

--- a/code/modules/urist/antagonist/revenant/revenant_core.dm
+++ b/code/modules/urist/antagonist/revenant/revenant_core.dm
@@ -49,8 +49,7 @@ GLOBAL_LIST(revenant_powerinstances)
 	id = MODE_BSREVENANT
 	role_text = "Bluespace Revenant"
 	role_text_plural = "Bluespace Revenants"
-	restricted_jobs = list(/datum/job/captain, /datum/job/hos)
-	protected_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/detective)
+	restricted_jobs = list(/datum/job/captain, /datum/job/hos, /datum/job/officer, /datum/job/warden, /datum/job/detective)
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/cyborg, /datum/job/submap)
 	feedback_tag = "revenant_objective"
 
@@ -67,4 +66,3 @@ GLOBAL_LIST(revenant_powerinstances)
 	initial_spawn_req = 1
 	initial_spawn_target = 2
 	skill_setter = /datum/antag_skill_setter/station
-

--- a/code/modules/urist/items/clothes/belt.dm
+++ b/code/modules/urist/items/clothes/belt.dm
@@ -9,7 +9,7 @@
 	icon_override = 'icons/uristmob/belt_mirror.dmi'
 	icon_state = "beltRobo"
 	storage_slots = 7
-	can_hold = list(
+	contents_allowed = list(
  	/obj/item/crowbar,
  	/obj/item/screwdriver,
  	/obj/item/weldingtool,
@@ -39,7 +39,7 @@
 	icon = 'icons/urist/items/clothes/belt.dmi'
 	icon_override = 'icons/uristmob/belt_mirror.dmi'
 	storage_slots = 1
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/modular_computer/pda
 		)
 
@@ -110,6 +110,6 @@
 	storage_slots = 7
 	max_w_class = 3
 	max_storage_space = 24
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item
 		)

--- a/code/modules/urist/items/clothes/namert.dm
+++ b/code/modules/urist/items/clothes/namert.dm
@@ -62,7 +62,7 @@
 	storage_slots = 7
 	max_w_class = 3
 	max_storage_space = 28
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/grenade,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/handcuffs,

--- a/code/modules/urist/items/clothes/uristclothes.dm
+++ b/code/modules/urist/items/clothes/uristclothes.dm
@@ -723,7 +723,7 @@ Update 26/07/2014 - All generic clothing goes under obj/item/clothing/under/uris
 	icon = 'icons/urist/items/old_bay_custom_items.dmi'
 	item_icons = list("slot_suit" = 'icons/mob/onmob/onmob_suit.dmi')
 	icon_state = "deus_blueshield"
-	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_C)
+	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_CHEST)
 
 //more pants
 
@@ -790,7 +790,7 @@ Update 26/07/2014 - All generic clothing goes under obj/item/clothing/under/uris
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	blood_overlay_type = "armorblood"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
-	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_C)
+	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_CHEST)
 	accessories = list(/obj/item/clothing/accessory/armor_plate/medium)
 
 /obj/item/clothing/under/urist/blackwarden
@@ -1294,8 +1294,7 @@ Update 26/07/2014 - All generic clothing goes under obj/item/clothing/under/uris
 	item_state = "nervasecarmour"
 	blood_overlay_type = "armorblood"
 	armor = list(melee = 50, bullet = 45, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
-	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S)
-	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S)
+	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_LEGS, ACCESSORY_SLOT_ARMOR_STORAGE)
 	accessories = list(/obj/item/clothing/accessory/storage/pouches/large)
 
 //rescued colored spacesuits from bay. too nice to let go

--- a/code/modules/urist/items/miscitems.dm
+++ b/code/modules/urist/items/miscitems.dm
@@ -821,9 +821,9 @@
 	icon_state = "fork"
 
 /obj/random/utensil/spawn_choices()
-	return list(/obj/item/material/kitchen/utensil/fork,
-				/obj/item/material/kitchen/utensil/spoon,
-				/obj/item/material/kitchen/utensil/spork
+	return list(/obj/item/material/utensil/fork,
+				/obj/item/material/utensil/spoon,
+				/obj/item/material/utensil/spork
 				)
 
 /obj/random/officetoy

--- a/code/modules/urist/items/tgitems.dm
+++ b/code/modules/urist/items/tgitems.dm
@@ -99,7 +99,7 @@ Please only put items here that don't have a huge definition - Glloyd											
 	max_storage_space = 21 //check values!
 	max_w_class = 3
 	w_class = 4 //Bigger than a book because physics
-	can_hold = list(/obj/item/book, /obj/item/spellbook) //No bibles, consistent with bookcase
+	contents_allowed = list(/obj/item/book, /obj/item/spellbook) //No bibles, consistent with bookcase
 
 //moo000ooo000ooo
 
@@ -326,7 +326,7 @@ Please only put items here that don't have a huge definition - Glloyd											
 	storage_slots = 5
 	max_storage_space = 15 //check values!
 	level = 1
-	cant_hold = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
+	contents_banned = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
 
 /obj/item/storage/backpack/satchel/flat/hide(intact)
 	if(intact)
@@ -372,7 +372,7 @@ Please only put items here that don't have a huge definition - Glloyd											
 	icon_state = "cig_paper_pack"
 	storage_slots = 10
 	key_type = /obj/item/paper/cig
-	can_hold = list(/obj/item/paper/cig)
+	contents_allowed= list(/obj/item/paper/cig)
 	startswith = list(/obj/item/paper/cig/fancy/nt = 10)
 
 

--- a/code/modules/urist/kingrescues/guns.dm
+++ b/code/modules/urist/kingrescues/guns.dm
@@ -95,7 +95,7 @@
 	max_storage_space = 200
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_LARGE
-	can_hold = list(/obj/item/ammo_casing/musket, /obj/item/ammo_casing/musket/short, /obj/item/ammo_casing/musket/flintlock)
+	contents_allowed = list(/obj/item/ammo_casing/musket, /obj/item/ammo_casing/musket/short, /obj/item/ammo_casing/musket/flintlock)
 	allow_quick_gather = 1
 	allow_quick_empty = 1
 	use_to_pickup = 1

--- a/code/modules/urist/machinery/uristvending.dm
+++ b/code/modules/urist/machinery/uristvending.dm
@@ -21,7 +21,7 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	products = list(/obj/item/clothing/suit/chickensuit = 1,/obj/item/clothing/head/chicken = 1,/obj/item/clothing/under/gladiator = 1,
 					/obj/item/clothing/head/helmet/gladiator = 1,/obj/item/clothing/under/gimmick/rank/captain/suit = 1,/obj/item/clothing/head/flatcap = 1,
 					/obj/item/clothing/suit/storage/toggle/labcoat/mad = 1,/obj/item/clothing/glasses/gglasses = 1,/obj/item/clothing/shoes/jackboots = 1,
-					/obj/item/clothing/under/schoolgirl = 1,/obj/item/clothing/head/kitty = 1,/obj/item/clothing/under/blackskirt = 1,/obj/item/clothing/head/beret = 1,
+					/obj/item/clothing/under/schoolgirl = 1,/obj/item/clothing/head/kitty = 1,/obj/item/clothing/under/skirt = 1,/obj/item/clothing/head/beret = 1,
 					/obj/item/clothing/accessory/wcoat = 1,/obj/item/clothing/under/suit_jacket = 1,/obj/item/clothing/head/that =1,/obj/item/clothing/head/cueball = 1,
 					/obj/item/clothing/under/scratch = 1,/obj/item/clothing/under/kilt = 1,/obj/item/clothing/head/beret = 1,/obj/item/clothing/accessory/wcoat = 1,
 					/obj/item/clothing/glasses/monocle =1,/obj/item/clothing/head/bowler = 1,/obj/item/cane = 1,/obj/item/clothing/under/sl_suit = 1,
@@ -73,13 +73,13 @@ Please keep it tidy, by which I mean put comments describing the item before the
 	vend_reply = "Enjoy your beautiful new dress!"
 	icon_state = "dress"
 	products = list(/obj/item/clothing/under/urist/dress/teal = 5,/obj/item/clothing/under/urist/dress/yellow = 5,/obj/item/clothing/under/urist/dress/white1 = 5,/obj/item/clothing/under/urist/dress/white2 = 5,/obj/item/clothing/under/dress/dress_fire = 5,/obj/item/clothing/under/dress/dress_green = 5,/obj/item/clothing/under/dress/dress_orange = 5,/obj/item/clothing/under/dress/dress_pink = 5,
-					/obj/item/clothing/under/dress/dress_saloon = 5,/obj/item/clothing/under/dress/plaid_blue = 5,/obj/item/clothing/under/dress/plaid_purple = 5,/obj/item/clothing/under/dress/plaid_red = 5,/obj/item/clothing/under/urist/dress/red = 5,
+					/obj/item/clothing/under/dress/dress_saloon = 5,/obj/item/clothing/under/skirt/plaid_blue = 5,/obj/item/clothing/under/urist/dress/red = 5,
 					/obj/item/clothing/under/sundress = 5,/obj/item/clothing/under/wedding/bride_white = 5,/obj/item/clothing/under/urist/formal/blacktango = 5,
 					/obj/item/clothing/under/urist/dress/white3 = 5,/obj/item/clothing/under/urist/dress/pink = 5,/obj/item/clothing/under/urist/dress/gold = 5,
 					/obj/item/clothing/under/urist/dress/purple = 5,/obj/item/clothing/under/urist/dress/green = 5,/obj/item/clothing/under/urist/dress/black = 5,
 					/obj/item/clothing/under/urist/dress/polkadot = 5,/obj/item/clothing/under/urist/dress/dress_blouse = 5,/obj/item/clothing/under/sakura_hokkaido_kimono = 1,/obj/item/clothing/under/urist/dress/princess = 2,/obj/item/clothing/head/princessbow = 2)
 	prices = list(/obj/item/clothing/under/urist/dress/teal = 250,/obj/item/clothing/under/urist/dress/yellow = 250,/obj/item/clothing/under/urist/dress/white1 = 250,/obj/item/clothing/under/urist/dress/white2 = 250,/obj/item/clothing/under/dress/dress_fire = 250,/obj/item/clothing/under/dress/dress_green = 250,/obj/item/clothing/under/dress/dress_orange = 250,/obj/item/clothing/under/dress/dress_pink = 250,
-					/obj/item/clothing/under/dress/dress_saloon = 250,/obj/item/clothing/under/dress/plaid_blue = 250,/obj/item/clothing/under/dress/plaid_purple = 250,/obj/item/clothing/under/dress/plaid_red = 250,/obj/item/clothing/under/urist/dress/red = 250,
+					/obj/item/clothing/under/dress/dress_saloon = 250,/obj/item/clothing/under/skirt/plaid_blue = 250,/obj/item/clothing/under/urist/dress/red = 250,
 					/obj/item/clothing/under/urist/dress/white3 = 250, /obj/item/clothing/under/urist/dress/pink = 250, /obj/item/clothing/under/urist/dress/gold = 250, /obj/item/clothing/under/urist/dress/purple = 250, /obj/item/clothing/under/urist/dress/green = 250, /obj/item/clothing/under/urist/dress/black = 250,
 					/obj/item/clothing/under/sundress = 250,/obj/item/clothing/under/wedding/bride_white = 250,/obj/item/clothing/under/urist/formal/blacktango = 250,
 					/obj/item/clothing/under/urist/dress/polkadot = 250,/obj/item/clothing/under/urist/dress/dress_blouse = 250,/obj/item/clothing/under/sakura_hokkaido_kimono = 600,/obj/item/clothing/under/urist/dress/princess = 500,/obj/item/clothing/head/princessbow = 100)

--- a/code/modules/urist/modules/newtrading/stations.dm
+++ b/code/modules/urist/modules/newtrading/stations.dm
@@ -11,7 +11,6 @@
 	var/busy = FALSE
 	var/spawn_ships = FALSE
 	var/mob/living/simple_animal/hostile/overmapship/patrolship = null //if you piss us off, we start spawning the big boys
-	known = TRUE
 	icon = 'icons/urist/misc/overmap.dmi'
 	icon_state = "station1"
 	var/station_holder = null //the holder for station battles
@@ -80,4 +79,3 @@
 
 /obj/overmap/visitable/sector/station/hostile
 	hide_from_reports = TRUE
-	known = FALSE

--- a/code/modules/urist/spells.dm
+++ b/code/modules/urist/spells.dm
@@ -6,7 +6,7 @@
 	summon_type = list(
 		/obj/item/reagent_containers/food/snacks/sliceable/cheesewheel/fresh,
 		/obj/item/reagent_containers/food/snacks/cheesewedge/fresh,
-		/obj/item/reagent_containers/food/drinks/jar,
+		/obj/item/glass_jar,
 		/obj/item/gun/launcher/foam/revolver,
 		/obj/item/reagent_containers/food/condiment/small/saltshaker,
 		/obj/random/action_figure,

--- a/code/modules/urist/structures/pits.dm
+++ b/code/modules/urist/structures/pits.dm
@@ -189,7 +189,7 @@
 		/obj/item/clothing/suit/storage/toggle/brown_jacket,
 		/obj/item/clothing/suit/storage/toggle/hoodie,
 		/obj/item/clothing/suit/storage/toggle/hoodie/black,
-		/obj/item/clothing/suit/poncho/colored
+		/obj/item/clothing/suit/poncho
 		)
 	loot = pick(suits)
 	new loot(C)

--- a/maps/away/abandoned_colony/abandoned_colony.dm
+++ b/maps/away/abandoned_colony/abandoned_colony.dm
@@ -23,7 +23,6 @@
 	desc = "A former Terran Confederation colony, evacuated during the Galactic Crisis. It is now a 'Graveworld', one of the many broken monuments to the billions of dead and displaced across the galaxy. However, sensors are detecting signs of life on the surface."
 	icon_state = "globe"
 	color = "#7f8274"
-	known = FALSE
 	assigned_contracts = list(/datum/contract/shiphunt/graveworld_alien)
 	initial_generic_waypoints = list(
 		"nav_abandoned_colony_1",

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -179,10 +179,10 @@
 	return PROCESS_KILL
 
 /turf/unsimulated/wall/supermatter/no_spread/attack_ghost(mob/user as mob)
-	user.examinate(src)
+	examinate(user, src)
 
 /turf/unsimulated/wall/supermatter/no_spread/attack_ai(mob/user as mob)
-	return user.examinate(src)
+	return examinate(user, src)
 
 /turf/unsimulated/wall/supermatter/no_spread/attack_hand(mob/user as mob)
 	user.visible_message("<span class=\"warning\">\The [user] reaches out and touches \the [src]... And then blinks out of existance.</span>",\

--- a/maps/away/crystalized_drugs/crystalized_drugs.dm
+++ b/maps/away/crystalized_drugs/crystalized_drugs.dm
@@ -16,7 +16,6 @@
 	name = "bluespace wake traces"
 	desc = "Initial sector readings reported numerous bluespace wake traces from within this sector. Sensor reports indicate asteroids with abnormal refraction indexes are detected along with energy spikes."
 	icon_state = "object"
-	known = FALSE
 
 /obj/overmap/visitable/sector/drug_lab/generate_skybox()
 	var/image/res = overlay_image('icons/skybox/rockbox.dmi', "rockbox", COLOR_ASTEROID_ROCK, RESET_COLOR)

--- a/maps/away/crystalized_drugs/crystalized_drugs_items.dm
+++ b/maps/away/crystalized_drugs/crystalized_drugs_items.dm
@@ -88,8 +88,8 @@ var/global/const/access_drug_smuggler = "ACCESS_DRUG_SMUGGLER"
 /obj/random/ammo_magazine_smug
 	name = "Random Ammo Magazine"
 	desc = "This is smuggler's random ammo magazine."
-	icon = 'icons/obj/weapon/ammo.dmi'
-	icon_state = "magnum"
+	icon = 'icons/obj/weapons/ammo.dmi'
+	icon_state = "spdloader_small"
 
 /obj/random/ammo_magazine_smug/spawn_choices()
 	return list(

--- a/maps/away/forest/forest.dm
+++ b/maps/away/forest/forest.dm
@@ -64,7 +64,6 @@
 	name = "temperate planetoid"
 	desc = "Scanner report shows a derelict comm bouy in orbit; recovered data shows little info beyond a breathable atmosphere. Sensors pick up a degraded signal from an area in the northern hemisphere."
 	icon_state = "globe"
-	known = FALSE
 	in_space = FALSE
 	color = "#035e15"
 	initial_generic_waypoints = list(

--- a/maps/away/glloyd_jungle/glloyd_jungle.dm
+++ b/maps/away/glloyd_jungle/glloyd_jungle.dm
@@ -14,7 +14,6 @@
 	name = "Jungle planetoid"
 	desc = "Geneseeded world detected, possible intelligent life detected."
 	icon_state = "globe"
-	known = FALSE
 	color = "#538224"
 	water_color = "#1e160a"
 	initial_generic_waypoints = list(

--- a/maps/away/icarus/icarus.dm
+++ b/maps/away/icarus/icarus.dm
@@ -4,7 +4,6 @@
 	name = "forest planetoid"
 	desc = "Sensors detect anomalous radiation area with the presence of artificial structures."
 	icon_state = "globe"
-	known = 0
 	initial_generic_waypoints = list(
 		"nav_icarus_1",
 		"nav_icarus_2",

--- a/maps/away/russianderelict/russianderelict.dm
+++ b/maps/away/russianderelict/russianderelict.dm
@@ -83,7 +83,6 @@
 	desc = "Sensors detect an orbital station with an unusual profile and no life signs."
 	icon_state = "object"
 	assigned_contracts = list(/datum/contract/russianderelict)
-	known = FALSE
 
 /datum/map_template/ruin/away_site/russianderelict
 	name = "Russian derelict"

--- a/maps/nerva/nerva_shuttles.dm
+++ b/maps/nerva/nerva_shuttles.dm
@@ -210,7 +210,7 @@
 	base_area = /area/spacestations/nanotrasenspace
 	base_turf = /turf/simulated/floor/reinforced
 
-/datum/shuttle/autodock/ferry/supply/drone/attempt_move(obj/effect/shuttle_landmark/destination)
+/datum/shuttle/autodock/ferry/supply/drone/attempt_move(obj/shuttle_landmark/destination)
 	if(!destination)
 		return FALSE
 

--- a/maps/nerva/obj/nerva_clothes.dm
+++ b/maps/nerva/obj/nerva_clothes.dm
@@ -159,9 +159,13 @@
 	item_state = "nervacosarmour"
 	blood_overlay_type = "armorblood"
 	armor = list(melee = 60, bullet = 50, laser = 45, energy = 30, bomb = 35, bio = 0, rad = 0)
-	valid_accessory_slots = list(ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S)
-	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMOR_A, ACCESSORY_SLOT_ARMOR_L, ACCESSORY_SLOT_ARMOR_S)
-	accessories = list(/obj/item/clothing/accessory/arm_guards/merc, /obj/item/clothing/accessory/leg_guards/merc, /obj/item/clothing/accessory/storage/pouches/large, /obj/item/clothing/accessory/armor/tag/nerva)
+	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_ARMS, ACCESSORY_SLOT_ARMOR_LEGS, ACCESSORY_SLOT_ARMOR_STORAGE)
+	accessories = list(
+		/obj/item/clothing/accessory/arm_guards/merc,
+		/obj/item/clothing/accessory/leg_guards/merc,
+		/obj/item/clothing/accessory/storage/pouches/large,
+		/obj/item/clothing/accessory/armor/tag/nerva
+		)
 
 /obj/item/clothing/suit/armor/pcarrier/medium/nerva
 	accessories = list(/obj/item/clothing/accessory/armor_plate/medium, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/nerva)

--- a/maps/nerva/obj/nerva_machinery.dm
+++ b/maps/nerva/obj/nerva_machinery.dm
@@ -3,7 +3,7 @@
 	name = "Exploration suit cycler"
 	model_text = "Exploration"
 	req_access = list()
-	available_modifications = list(/singleton/item_modifier/space_suit/explorer)
+	available_modifications = list(/singleton/item_modifier/space_suit/sol/explorer)  // We might have to make our own urist ones to avoid the Sol stuff.
 	species = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI)
 
 /obj/machinery/suit_storage_unit/explorer

--- a/maps/random_ruins/exoplanet_ruins/crashed_shuttle/crashed_shuttle.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_shuttle/crashed_shuttle.dm
@@ -29,7 +29,6 @@
 	fuel_consumption = 4
 	defer_initialisation = TRUE
 	flags = SHUTTLE_FLAGS_PROCESS
-	skill_needed = SKILL_MIN
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
 
 /obj/machinery/computer/shuttle_control/explore/graysontug

--- a/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dm
+++ b/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dm
@@ -50,7 +50,6 @@
 	fuel_consumption = 4
 	defer_initialisation = TRUE
 	flags = SHUTTLE_FLAGS_PROCESS
-	skill_needed = SKILL_MIN
 	ceiling_type = /turf/simulated/floor/shuttle_ceiling
 
 /obj/machinery/computer/shuttle_control/explore/old_snz


### PR DESCRIPTION
- Removes Skills needed for use certain map shuttles.
- Readds Exploration RIG - (May need decoupling from bay lore)
- Fixes Accessory Tags for Nerva Items (Armors)
- obj/effect/shuttle_landmark error fix for nerva_shuttle
- var/known for aways no longer exists, removed for aways. it is now hide_from_reports which defaults to FALSE
- fixs magazine spawner icons on crystalized_drugs away.
- examine(user, src) fixes for bluespace river
- poncho/colored no longer exists, changes to poncho
- changes to dress, autodrobe, etc - skirt now defaults to black, some dresses are now defined as skirts w/ bay
- remove can_hold for contents_allowed for storage items.
- kitchen/utensils is now just utensils
- fixes bsr rev armblade due to bay's ling rework
- protected_jobs is replaced w/ restricted jobs, bsr, changeling and rev updated for this.
- glass jar fixed for spell
