### PR TITLE
Merge Map Fixing - Aways, Exoplanets, etc.

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3790,6 +3790,7 @@
 #include "maps\_maps.dm"
 #include "maps\deepmaint_wfc\wfc_deepmaint.dm"
 #include "maps\glloydstation\glloydstation_define.dm"
+#include "maps\nerva\obj\nerva_random.dm"
 #include "maps\RandomZLevels\maze1.dm"
 #include "maps\torch\torch_define.dm"
 #include "maps\wyrm\items\smcult.dm"

--- a/code/modules/urist/area&turf/turfs.dm
+++ b/code/modules/urist/area&turf/turfs.dm
@@ -326,3 +326,9 @@ transit/east is the same thing now AFAIK
 
 /turf/simulated/floor/tiled/airless
 	map_airless = TRUE
+
+/turf/simulated/floor/tiled/dark/airless
+	map_airless = TRUE
+
+/turf/simulated/floor/tiled/white/airless
+	map_airless = TRUE

--- a/maps/PlanetOutposts/jungle3.dmm
+++ b/maps/PlanetOutposts/jungle3.dmm
@@ -60,7 +60,7 @@
 "bh" = (/obj/structure/transit_tube{icon_state = "S-NE"},/turf/simulated/jungle/water/deep,/area/jungle)
 "bi" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/outpost/research/chemistry)
 "bj" = (/obj/structure/closet/hydrant{pixel_x = 0; pixel_y = 32},/turf/simulated/floor/plating,/area/outpost/research/chemistry)
-"bk" = (/obj/structure/table/standard,/obj/item/device/scanner/plant,/obj/item/cell/standard,/obj/item/stack/cable_coil/random,/obj/item/stack/cable_coil/random,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plating,/area/outpost/research/chemistry)
+"bk" = (/obj/structure/table/standard,/obj/item/device/scanner/plant,/obj/item/cell/standard,/obj/random/single/color/cable_coil,/obj/random/single/color/cable_coil,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plating,/area/outpost/research/chemistry)
 "bl" = (/obj/machinery/vending/hydroseeds,/turf/simulated/floor{dir = 8; icon_state = "whitegreen"},/area/outpost/research/chemistry)
 "bm" = (/obj/machinery/atmospherics/portables_connector{dir = 1},/obj/machinery/portable_atmospherics/hydroponics{closed_system = 1; name = "isolation tray"},/turf/simulated/floor{icon_state = "white"},/area/outpost/research/chemistry)
 "bn" = (/obj/machinery/seed_extractor,/obj/machinery/light{brightness_range = 9; dir = 4},/turf/simulated/floor{dir = 4; icon_state = "whitegreen"},/area/outpost/research/chemistry)

--- a/maps/away/abandoned_colony/abandoned_colony.dmm
+++ b/maps/away/abandoned_colony/abandoned_colony.dmm
@@ -1897,7 +1897,7 @@
 "fJ" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/mousetrap,
-/obj/item/material/kitchen/utensil/fork,
+/obj/item/material/utensil/fork,
 /obj/item/material/knife/kitchen,
 /turf/simulated/floor/tiled/dark,
 /area/planet/abandoned_colony)

--- a/maps/away/crystalized_drugs/crystalized_drugs-1.dmm
+++ b/maps/away/crystalized_drugs/crystalized_drugs-1.dmm
@@ -2989,7 +2989,7 @@
 /area/crystaldrugs/bacchus)
 "ux" = (
 /obj/structure/table/steel_reinforced/dark,
-/obj/item/material/kitchen/utensil/spork/silver,
+/obj/item/material/utensil/spork/silver,
 /obj/machinery/light/coldtint{
 	dir = 8;
 	icon_state = "tube_map"

--- a/maps/away/crystalized_drugs/crystalized_drugs_active.dmm
+++ b/maps/away/crystalized_drugs/crystalized_drugs_active.dmm
@@ -85,13 +85,13 @@
 /turf/template_noop,
 /area/template_noop)
 "A" = (
-/mob/living/simple_animal/hostile/pirate/ranged{
+/mob/living/simple_animal/hostile/human/pirate/ranged{
 	hiddenfaction = /datum/factions/pirate
 	},
 /turf/template_noop,
 /area/template_noop)
 "B" = (
-/mob/living/simple_animal/hostile/pirate{
+/mob/living/simple_animal/hostile/human/pirate{
 	hiddenfaction = /datum/factions/pirate
 	},
 /turf/template_noop,

--- a/maps/away/forest/forest2.dmm
+++ b/maps/away/forest/forest2.dmm
@@ -18,15 +18,15 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stock_parts/keyboard,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random,
+/obj/random/single/color/cable_coil,
+/obj/random/single/color/cable_coil,
+/obj/random/single/color/cable_coil,
+/obj/random/single/color/cable_coil,
 /obj/item/stock_parts/keyboard,
 /obj/item/stock_parts/keyboard,
 /obj/item/stock_parts/keyboard,
 /obj/item/stock_parts/console_screen,
-/obj/item/stack/cable_coil/random,
+/obj/random/single/color/cable_coil,
 /turf/simulated/floor/planet/jungle/clear/underground,
 /area/planet/forest/cabin1)
 "af" = (
@@ -1002,8 +1002,8 @@
 /area/planet/forest)
 "vE" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/head/hardhat/EMS,
-/obj/item/clothing/head/hardhat/dblue,
+/obj/item/clothing/head/hardhat/light/medic,
+/obj/item/clothing/head/hardhat/blue,
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat,
 /obj/item/clothing/head/hardhat/orange,

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -815,7 +815,7 @@
 	dir = 4
 	},
 /obj/item/trash/plate,
-/obj/item/material/kitchen/utensil/fork,
+/obj/item/material/utensil/fork,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel2)
 "cL" = (

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -606,7 +606,7 @@
 /area/lar_maria/vir_main)
 "bO" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/vial/random_podchem,
+/obj/item/reagent_containers/glass/beaker/vial/ejected_datapod,
 /turf/simulated/floor/tiled/white/monotile,
 /area/lar_maria/vir_main)
 "bP" = (

--- a/maps/away/mobius_rift/mobius_rift.dmm
+++ b/maps/away/mobius_rift/mobius_rift.dmm
@@ -74,7 +74,7 @@
 /turf/simulated/floor/cult,
 /area/mobius_rift)
 "Q" = (
-/obj/structure/fountain,
+/obj/structure/fountain/strange/urist,
 /turf/simulated/floor/cult,
 /area/mobius_rift)
 "W" = (

--- a/maps/away/noctis/noctis-1.dmm
+++ b/maps/away/noctis/noctis-1.dmm
@@ -3861,7 +3861,7 @@
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/condiment/small/saltshaker,
 /obj/item/reagent_containers/food/condiment/small/peppermill,
-/obj/item/material/kitchen/utensil/fork,
+/obj/item/material/utensil/fork,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4;

--- a/maps/away/russianderelict/russianderelict.dmm
+++ b/maps/away/russianderelict/russianderelict.dmm
@@ -5764,22 +5764,6 @@
 	name = "ushanka"
 	},
 /obj/item/clothing/head/helmet/urist/wwii/soviethelm,
-/obj/item/clothing/head/ushanka/solgov{
-	desc = "A synthfur-lined hat for operating in cold environments.";
-	name = "ushanka"
-	},
-/obj/item/clothing/head/ushanka/solgov/army{
-	desc = "A synthfur-lined hat for operating in cold environments.";
-	name = "ushanka"
-	},
-/obj/item/clothing/head/ushanka/solgov/army/green{
-	desc = "A green synthfur-lined hat for operating in cold environments.";
-	name = "ushanka"
-	},
-/obj/item/clothing/head/ushanka/solgov/fleet{
-	desc = "A synthfur-lined hat for operating in cold environments.";
-	name = "ushanka"
-	},
 /obj/item/clothing/head/urist/wwii/sovietofficer,
 /obj/item/clothing/head/urist/wwii/sovietofficer,
 /obj/item/clothing/head/urist/pelt/bear/brown,
@@ -8363,7 +8347,7 @@
 /area/russianderelict/singularity_engine)
 "PU" = (
 /obj/structure/table/standard,
-/obj/item/stack/cable_coil/random,
+/obj/random/single/color/cable_coil,
 /obj/item/device/t_scanner,
 /obj/landmark/scorcher/certain,
 /turf/simulated/floor/tiled/airless,

--- a/maps/away/stations/pirate/pirate_station-1.dmm
+++ b/maps/away/stations/pirate/pirate_station-1.dmm
@@ -504,7 +504,7 @@
 "bR" = (
 /obj/structure/table/marble,
 /obj/item/trash/plate,
-/obj/item/material/kitchen/utensil/fork,
+/obj/item/material/utensil/fork,
 /turf/simulated/floor,
 /area/spacestations/pirate/station)
 "bS" = (

--- a/maps/nerva/nerva.dm
+++ b/maps/nerva/nerva.dm
@@ -81,13 +81,6 @@
 	#include "../away/meatstation/meatstation.dm"
 	#include "../away/scavver_gantry/scavver_gantry.dm"
 
-	/*#include "../../code/datums/music_tracks/chasing_time.dm"
-	#include "../../code/datums/music_tracks/absconditus.dm"
-	#include "../../code/datums/music_tracks/clouds_of_fire.dm"
-	#include "../../code/datums/music_tracks/endless_space.dm"
-	#include "../../code/datums/music_tracks/dilbert.dm"
-	#include "../../code/datums/music_tracks/space_oddity.dm"*/
-
 	//keep your clothing hacks to yourself
 	// #include "../torch/items/clothing/solgov-accessory.dm"	These don't seem to actually be used, but are causing issues with double-importing
 	#include "../torch/items/clothing/solgov-armor.dm"

--- a/maps/nerva/obj/nerva_random.dm
+++ b/maps/nerva/obj/nerva_random.dm
@@ -1,0 +1,18 @@
+// Nerva-related Random Obj/Turf/Mob Spawners - Seperated from Baystation to avoid merge issues later on.
+
+/obj/random/vendor/urist
+	name = "random urist vending machine"
+	desc = "This is a randomly selected vending machine."
+	icon = 'icons/obj/machines/vending.dmi'
+	icon_state = "green-outline"
+
+/obj/random/vendor/spawn_choices()
+	return list(/obj/machinery/vending/weeb,
+				/obj/machinery/vending/snix,
+				/obj/machinery/vending/soda,
+				/obj/machinery/vending/cigarette,
+				/obj/machinery/vending/coffee,
+				/obj/machinery/vending/whitedragon,
+				/obj/machinery/vending/cola,
+				/obj/machinery/vending/sol
+				)

--- a/maps/random_ruins/exoplanet_ruins/pioneer/pioneer.dmm
+++ b/maps/random_ruins/exoplanet_ruins/pioneer/pioneer.dmm
@@ -58,8 +58,8 @@
 /area/template_noop)
 "eV" = (
 /obj/structure/table/woodentable_reinforced/walnut,
-/obj/item/material/knife/table,
-/obj/item/material/kitchen/utensil/fork/plastic,
+/obj/item/material/knife,
+/obj/item/material/utensil/fork/plastic,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/lonepioneer/cabin)
 "ge" = (


### PR DESCRIPTION
- Fixes all type_path errors in maps.
- Adds missing airless tiles.
- Adds nerva-specific random vendor code, for later.
- Removes some old redundant nerva comments.
- NPC Fixes on Away Missions.
- Replaces Fountain with Urist version again on Maze Away.
- Readds Lar Maria exo-planet vial sample from previous Lar Maria PR, as path changed.

This should fix every single Away + Exoplanet Ruin we currently use for Nerva + Glloyd.