### PR TITLE
15 Apr 25 baymerge fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3791,7 +3791,6 @@
 #include "maps\deepmaint_wfc\wfc_deepmaint.dm"
 #include "maps\glloydstation\glloydstation_define.dm"
 #include "maps\RandomZLevels\maze1.dm"
-#include "maps\torch\torch_define.dm"
 #include "maps\wyrm\items\smcult.dm"
 #include "maps\wyrm\items\clothing\corporate.dm"
 #include "maps\wyrm\obj\alien.dm"

--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT_STEP(index_to_flag, 0)
 
 #if DM_VERSION >= 516
 GLOBAL_ALIST_INIT_STEP(flag_to_index, 0)
-	flag_to_index = new (MAX_FLAG_INDEX)
+	flag_to_index = new ()
 	for (var/i in 1 to MAX_FLAG_INDEX)
 		flag_to_index[RFLAG(i)] = i
 #endif

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -21,7 +21,7 @@ GLOBAL_TYPED_AS(actual_error_file_line, /regex, regex("^%% (.*?),(.*?) %% "))
 	var/eline = E.line
 
 	var/regex/actual_error_file_line = GLOB.actual_error_file_line
-	if(actual_error_file_line.Find_char(E.name))
+	if(actual_error_file_line?.Find_char(E.name))
 		efile = actual_error_file_line.group[1]
 		eline = actual_error_file_line.group[2]
 		E.name = replacetext_char(E.name, actual_error_file_line, "")

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -139,11 +139,6 @@
 		var/datum/firemode/new_mode = firemodes[sel_mode]
 		new_mode.apply_to(src)
 
-/obj/item/gun/update_twohanding()
-	if(one_hand_penalty)
-		update_icon() // In case item_state is set somewhere else.
-	..()
-
 /obj/item/gun/on_update_icon()
 	var/mob/living/M = loc
 	ClearOverlays()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -130,7 +130,6 @@
 			else
 				icon_state = "[initial(icon_state)][0]"
 			update_icon()
-			update_held_icon()
 		else
 			to_chat(user, "<span class='warning'>[src] is empty.</span>")
 	else

--- a/code/modules/urist/items/guns.dm
+++ b/code/modules/urist/items/guns.dm
@@ -274,7 +274,6 @@ the sprite and make my own projectile -Glloyd*/
 		icon_state = (ammo_magazine)? "M16-GL" : "M16-GL-empty"
 	else
 		icon_state = (ammo_magazine)? "M16" : "M16-empty"
-	update_held_icon()
 
 /obj/item/gun/projectile/automatic/m16/gl
 	name = "\improper M16-GL Assault Rifle"

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -21,36 +21,10 @@
 /obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"eP" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/item/stack/material/aluminium/fifty,
-/obj/item/stack/material/aluminium/fifty,
-/obj/item/stack/material/deuterium/fifty,
-/obj/item/stack/material/diamond/ten,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/glass/phoronglass,
-/obj/item/stack/material/glass/reinforced/fifty,
-/obj/item/stack/material/gold/ten,
-/obj/item/stack/material/iron,
-/obj/item/stack/material/mhydrogen/ten,
-/obj/item/stack/material/nullglass/fifty,
-/obj/item/stack/material/ocp/fifty,
-/obj/item/stack/material/osmium/ten,
-/obj/item/stack/material/phoron/fifty,
-/obj/item/stack/material/plasteel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/platinum/ten,
-/obj/item/stack/material/rods/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/titanium/fifty,
-/obj/item/stack/material/tritium/fifty,
-/obj/item/stack/material/uranium/fifty,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "gk" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
 /obj/floor_decal/corner/blue/diagonal,
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/enzyme,
@@ -60,13 +34,6 @@
 "gm" = (
 /obj/machinery/light,
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/cell_charger,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"gM" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "gO" = (
@@ -147,7 +114,8 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/machinery/botany/editor,
+/obj/machinery/reagentgrinder/juicer,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "lM" = (
@@ -157,12 +125,6 @@
 /obj/item/device/robotanalyzer,
 /obj/item/device/scanner/health,
 /obj/item/storage/firstaid/adv,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"lQ" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_soft/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "ms" = (
@@ -189,13 +151,13 @@
 	icon_state = "1-2"
 	},
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "nu" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "nw" = (
@@ -212,32 +174,26 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "oy" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
 /obj/floor_decal/corner/blue/diagonal,
-/obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "oP" = (
 /turf/space,
 /area/space)
-"oU" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "oW" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/structure/table/glass,
 /obj/item/storage/box/latexgloves,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "pD" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qw" = (
@@ -246,17 +202,6 @@
 	},
 /turf/space,
 /area/space)
-"qx" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/item/stack/material/cardboard/fifty,
-/obj/item/stack/material/cloth,
-/obj/item/stack/material/generic/bone,
-/obj/item/stack/material/generic/brick,
-/obj/item/stack/material/generic/skin,
-/obj/item/stack/material/leather,
-/obj/item/stack/material/wood,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "qA" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/cooker/grill,
@@ -275,21 +220,9 @@
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"tn" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/rack,
-/obj/item/stack/animalhide/cat,
-/obj/item/stack/animalhide/corgi,
-/obj/item/stack/animalhide/human,
-/obj/item/stack/animalhide/lizard,
-/obj/item/stack/animalhide/xeno,
-/obj/item/stack/animalhide/monkey,
-/obj/item/stack/hairlesshide,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "uA" = (
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/vitals_monitor,
+/obj/machinery/computer/operating,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "uM" = (
@@ -338,33 +271,21 @@
 /obj/machinery/cooker/oven,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"xr" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/floor_light/mapped_off{
-	default_light_outer_range = 6;
-	default_light_inner_range = 2
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "xu" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xA" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/gibber,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "yq" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/item/reagent_containers/syringe,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"zp" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "zN" = (
@@ -392,7 +313,7 @@
 /area/medical/surgery)
 "Dh" = (
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/botany/extractor,
+/obj/machinery/reagent_temperature,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "DL" = (
@@ -401,12 +322,6 @@
 "Eb" = (
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/robotics_fabricator,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"Eq" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_alc/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "HE" = (
@@ -461,15 +376,11 @@
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"NM" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "NP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/cooking/still,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "OD" = (
@@ -489,16 +400,12 @@
 /obj/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
-"QG" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "QN" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/reagentgrinder/juicer,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "QY" = (
@@ -536,10 +443,6 @@
 	pixel_y = 5
 	},
 /obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "RG" = (
@@ -571,19 +474,6 @@
 /obj/floor_decal/corner/blue/diagonal,
 /obj/machinery/bodyscanner{
 	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"Uq" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"UD" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
@@ -635,12 +525,6 @@
 /obj/floor_decal/corner/blue/diagonal,
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"Zl" = (
-/obj/floor_decal/corner/blue/diagonal,
-/obj/structure/table/standard,
-/obj/machinery/fabricator/micro/bartender,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "Zq" = (
@@ -1313,12 +1197,12 @@ HE
 HE
 HE
 HE
+Dh
 HE
 HE
 HE
 HE
-QG
-oU
+HE
 DL
 oP
 oP
@@ -1348,11 +1232,11 @@ Eb
 HE
 KN
 VS
-nu
-zp
 HE
-pD
-UD
+HE
+HE
+HE
+HE
 DL
 oP
 oP
@@ -1381,8 +1265,8 @@ HE
 HE
 HE
 HE
-tn
-qx
+HE
+HE
 HE
 HE
 HE
@@ -1452,7 +1336,7 @@ HE
 HE
 HE
 HE
-SL
+HE
 HE
 gO
 DL
@@ -1482,7 +1366,7 @@ XT
 ms
 CJ
 HE
-xr
+HE
 HE
 HE
 HE
@@ -1510,14 +1394,14 @@ oP
 oP
 oP
 DL
-OQ
-RG
+HE
+XT
 XT
 Wk
 Yt
-Zl
 HE
-lQ
+HE
+HE
 HE
 HE
 HE
@@ -1544,17 +1428,17 @@ oP
 oP
 oP
 DL
-gM
+OQ
 HE
 vD
 Nd
 HE
 wF
 HE
-NM
 HE
 HE
-kA
+HE
+SL
 vL
 HE
 DL
@@ -1585,10 +1469,10 @@ qA
 HE
 jM
 HE
-Eq
 HE
 HE
-eP
+HE
+kA
 Eb
 NH
 DL
@@ -1616,11 +1500,11 @@ jS
 yq
 nw
 jo
-HE
+pD
 gk
 HE
 xA
-HE
+NP
 HE
 HE
 HE
@@ -1651,9 +1535,9 @@ HE
 HE
 HE
 HE
+nu
 HE
-HE
-HE
+nu
 HE
 HE
 HE
@@ -1684,11 +1568,11 @@ xu
 xu
 XF
 lf
-Dh
+HE
 QN
-Uq
+HE
 oy
-NP
+HE
 QY
 Ii
 iG

--- a/maps/example/example_unit_testing.dm
+++ b/maps/example/example_unit_testing.dm
@@ -1,8 +1,8 @@
 /datum/map/example
 	// Unit test exemptions
 	apc_test_exempt_areas = list(
-		/area/space = EXEMPT_ALL,
-		/area/shuttle/escape = EXEMPT_ALL,
+		/area/space = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/shuttle/escape = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/constructionsite = NO_AIR_ALARM|NO_FIRE_ALARM,
 		/area/medical/surgery = NO_AIR_ALARM|NO_FIRE_ALARM,
 		/area/maintenance/fsmaint2 = NO_AIR_ALARM|NO_FIRE_ALARM
@@ -44,8 +44,7 @@
 		/area/scom,
 		/area/planet,
 		/area/jungleoutpost,
-		/area/map_template,
-		/area/icarus
+		/area/map_template
 	)
 	area_usage_test_exempted_areas = list(
 		/area/beach,


### PR DESCRIPTION
fix: Fixes the cursed gun atom init bug (sneaky endless loop between two calls)
fix: Removes some other now-unnecessary icon calls in guncode.
fix: Fixes up bad areas in example_unit_testing.dm
fix: Fixes up bad alist init in 516 (that one's on Bay)
fix: Resets Example Z2 to Bay. Pain to maintain.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->