### PR TITLE
Baymerge Map Cleanup - Nerva + Some Away Fixes.

### DIFF
--- a/maps/antag_spawn/heist/heist_base.dmm
+++ b/maps/antag_spawn/heist/heist_base.dmm
@@ -1063,7 +1063,7 @@
 "cx" = (
 /obj/machinery/door/airlock/hatch{
 	frequency = 1331;
-	icon_state = "door_closed";
+	icon_state = "closed";
 	id_tag = "vox_northwest_lock"
 	},
 /obj/machinery/shield_diffuser,
@@ -1255,7 +1255,7 @@
 "cS" = (
 /obj/machinery/door/airlock/hatch{
 	frequency = 1331;
-	icon_state = "door_closed";
+	icon_state = "closed";
 	id_tag = "vox_southwest_lock"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -184,7 +184,7 @@
 "aD" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_closed";
+	icon_state = "closed";
 	id_tag = "casino_dock_outer";
 	name = "Docking Port Airlock"
 	},
@@ -278,7 +278,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
-	icon_state = "door_closed";
+	icon_state = "closed";
 	id_tag = "casino_dock_inner";
 	name = "Docking Port Airlock"
 	},

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -1907,7 +1907,7 @@
 /area/constructionsite/maintenance)
 "gf" = (
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "door_closed";
+	icon_state = "closed";
 	name = "AI Upload Access"
 	},
 /turf/simulated/floor/bluegrid,
@@ -1939,7 +1939,7 @@
 /area/constructionsite/ai)
 "gn" = (
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "door_closed";
+	icon_state = "closed";
 	name = "AI Upload"
 	},
 /turf/simulated/floor/bluegrid,
@@ -2124,7 +2124,7 @@
 /area/constructionsite/hallway/aft)
 "gZ" = (
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "door_closed";
+	icon_state = "closed";
 	name = "AI Upload Access"
 	},
 /turf/simulated/floor/bluegrid,

--- a/maps/away/forest/forest2.dmm
+++ b/maps/away/forest/forest2.dmm
@@ -162,7 +162,7 @@
 /area/planet/forest/cabin1)
 "aQ" = (
 /obj/structure/fence/door{
-	icon_state = "door_closed";
+	icon_state = "closed";
 	dir = 8
 	},
 /turf/simulated/floor/planet/temperate,

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -22,7 +22,7 @@
 "ag" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1439;
-	icon_state = "door_closed"
+	icon_state = "closed"
 	},
 /turf/simulated/floor,
 /area/smugglers/base)
@@ -76,7 +76,7 @@
 "aq" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1439;
-	icon_state = "door_closed";
+	icon_state = "closed";
 	name = "Internal Airlock"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black,

--- a/maps/nerva/nerva-1.dmm
+++ b/maps/nerva/nerva-1.dmm
@@ -389,11 +389,9 @@
 	info = "i don't think i'll last much longer. they forgot about me. they left me. they left me to die. <br> it's so cold here. so cold. <br> it is peaceful in the end... <br> it will not be peaceful for those who left me here... <br> the cold... can't write. <br> this is it then... goodb..... <br> theyleftmetheyleftmetheyleftmetheyleftme..."
 	},
 /obj/item/clothing/suit/urist/welderapron,
-/obj/item/scalpel{
-	pixel_y = 15
-	},
 /obj/decal/cleanable/cobweb,
 /obj/item/remains/human,
+/obj/item/scalpel/basic,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
 "ba" = (
@@ -1048,7 +1046,8 @@
 "cr" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = 3
+	pixel_y = 3;
+	icon_state = "rg0"
 	},
 /obj/random/contraband,
 /turf/simulated/floor/plating,
@@ -4255,7 +4254,9 @@
 /area/maintenance/fourth_deck/afp)
 "hR" = (
 /obj/structure/table/woodentable/walnut,
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /obj/item/crowbar,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afp)
@@ -5727,11 +5728,6 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/computer/modular/preset/nervacommand{
-	autorun_program = /datum/computer_file/program/comm;
-	dir = 8;
-	icon_state = "console"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10;
 	icon_state = "intact-scrubbers"
@@ -5741,6 +5737,9 @@
 	name = "Station Intercom (Command)";
 	pixel_x = 22;
 	pixel_y = 0
+	},
+/obj/machinery/computer/modular/preset/nervacommand{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/command/weapons_command)
@@ -6465,10 +6464,6 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/computer/modular/preset/nervacommand{
-	dir = 8;
-	icon_state = "console"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10;
@@ -6476,6 +6471,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
+	},
+/obj/machinery/computer/modular/preset/nervacommand{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/command/weapons_command)
@@ -8787,8 +8785,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "pF" = (
-/obj/structure/kitchenspike,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "pG" = (
@@ -9432,11 +9430,13 @@
 	pixel_y = -28
 	},
 /obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/food/snacks/mint,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "qD" = (
 /obj/machinery/cooker/cereal,
 /obj/machinery/light/small,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "qE" = (
@@ -9450,6 +9450,7 @@
 /obj/machinery/gibber{
 	dir = 4
 	},
+/obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "qG" = (
@@ -9805,7 +9806,9 @@
 /obj/structure/sign/deck/fourth{
 	pixel_y = -24
 	},
-/obj/machinery/vending/cola,
+/obj/random/vendor/urist{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "rf" = (
@@ -9848,7 +9851,9 @@
 /obj/structure/sign/deck/fourth{
 	pixel_y = -24
 	},
-/obj/machinery/vending/whitedragon,
+/obj/random/vendor/urist{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/centralfourth)
 "rj" = (
@@ -12237,15 +12242,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Pipe Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/afs)
 "vr" = (
@@ -13146,7 +13150,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Pipe Access"
@@ -14227,7 +14230,6 @@
 /area/engineering/substation/fourth_deck)
 "yJ" = (
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Pipe Access"
@@ -15795,7 +15797,9 @@
 /obj/structure/sign/greencross{
 	pixel_y = 32
 	},
-/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe{
+	icon_state = "rg0"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
 "BC" = (
@@ -16038,7 +16042,9 @@
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/handcuffs/cable/white,
-/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe{
+	icon_state = "rg0"
+	},
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/plating,
 /area/maintenance/fourth_deck/fs)
@@ -22091,7 +22097,6 @@
 /turf/simulated/floor/tiled/white,
 /area/command/seniorntoffice)
 "RP" = (
-/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "RQ" = (
@@ -22336,6 +22341,7 @@
 /obj/floor_decal/corner/purple/half{
 	dir = 1
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/rnd/office)
 "SQ" = (
@@ -22396,7 +22402,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/logistics/fabwork)
 "Tb" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/kitchenspike,
+/obj/structure/curtain/medical,
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/freezer)
 "Ti" = (
@@ -23731,13 +23738,16 @@
 "Yp" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = 7
+	pixel_y = 7;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = 3
+	pixel_y = 3;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = -1
+	pixel_y = -1;
+	icon_state = "rg0"
 	},
 /obj/floor_decal/corner/paleblue{
 	dir = 9
@@ -24280,7 +24290,9 @@
 	dir = 4;
 	icon_state = "intact-scrubbers"
 	},
-/obj/item/storage/fancy/vials,
+/obj/item/storage/fancy/vials{
+	icon_state = "vialbox0"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/extstorage)
 "ZL" = (

--- a/maps/nerva/nerva-2.dmm
+++ b/maps/nerva/nerva-2.dmm
@@ -1067,6 +1067,9 @@
 /area/medical/locker)
 "acA" = (
 /obj/structure/morgue,
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "acB" = (
@@ -1512,15 +1515,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/treatment)
 "adB" = (
-/obj/machinery/bodyscanner{
-	dir = 1;
-	icon_state = "body_scanner_0"
-	},
 /obj/floor_decal/corner/pink{
 	dir = 10
 	},
 /obj/floor_decal/corner/pink{
 	dir = 5
+	},
+/obj/machinery/bodyscanner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/treatment)
@@ -1805,8 +1807,7 @@
 	dir = 5
 	},
 /obj/machinery/body_scanconsole{
-	dir = 1;
-	icon_state = "body_scannerconsole"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/treatment)
@@ -2145,6 +2146,8 @@
 	pixel_y = -2
 	},
 /obj/item/storage/box/handcuffs,
+/obj/item/clothing/glasses/ballistic,
+/obj/item/clothing/glasses/ballistic,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
 "aeG" = (
@@ -2893,16 +2896,17 @@
 	pixel_x = 1;
 	pixel_y = 2
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "afV" = (
 /obj/structure/table/standard,
 /obj/item/autopsy_scanner,
-/obj/item/scalpel,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4;
 	icon_state = "map_scrubber_on"
 	},
+/obj/item/scalpel/basic,
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "afW" = (
@@ -3190,12 +3194,12 @@
 	dir = 4;
 	icon_state = "intact-supply"
 	},
+/obj/structure/table/woodentable_reinforced/walnut,
+/obj/machinery/door/firedoor,
 /obj/item/storage/box/donkpocket_mixed{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/structure/table/woodentable_reinforced/walnut,
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "ags" = (
@@ -3347,7 +3351,9 @@
 	name = "Pill Cabinet";
 	pixel_y = 0
 	},
-/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
 /obj/item/storage/pill_bottle/antitox,
 /obj/item/storage/pill_bottle/tramadol,
 /obj/paint_stripe/paleblue,
@@ -5841,9 +5847,15 @@
 	},
 /obj/item/storage/pill_bottle/antitox,
 /obj/item/storage/pill_bottle/tramadol,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/inaprovaline,
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/inaprovaline{
+	icon_state = "rg0"
+	},
 /obj/paint_stripe/paleblue,
 /turf/simulated/wall/prepainted,
 /area/medical/storage)
@@ -7026,6 +7038,7 @@
 	},
 /obj/item/pen,
 /obj/item/paper_bin,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/medical/lobby)
 "amK" = (
@@ -7361,6 +7374,7 @@
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
+/obj/item/clothing/glasses/ballistic,
 /obj/item/clothing/head/helmet,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
@@ -8580,8 +8594,7 @@
 /area/medical/examroom)
 "apA" = (
 /obj/machinery/body_scanconsole{
-	dir = 4;
-	icon_state = "body_scannerconsole"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/examroom)
@@ -8591,16 +8604,15 @@
 	pixel_x = 22
 	},
 /obj/machinery/light,
-/obj/machinery/bodyscanner{
-	dir = 4;
-	icon_state = "body_scanner_0"
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/floor_decal/corner/paleblue{
 	dir = 6
+	},
+/obj/machinery/bodyscanner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/examroom)
@@ -8980,12 +8992,13 @@
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
 /obj/item/clothing/head/helmet,
-/obj/item/clothing/head/helmet,
 /obj/machinery/alarm{
 	dir = 4;
 	icon_state = "alarm0";
 	pixel_x = -24
 	},
+/obj/item/clothing/glasses/ballistic,
+/obj/item/clothing/head/helmet,
 /turf/simulated/floor/plating,
 /area/security/boardarmoury)
 "aqe" = (
@@ -9655,6 +9668,7 @@
 	name = "Security Checkpoint Shutters"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/material/bell,
 /turf/simulated/floor/tiled/dark,
 /area/security/checkpoint)
 "arg" = (
@@ -12659,13 +12673,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "avx" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "body_scanner_0"
-	},
 /obj/machinery/light{
 	dir = 1;
 	icon_state = "tube1"
+	},
+/obj/machinery/cryopod{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -12844,20 +12857,14 @@
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "avL" = (
-/obj/structure/table/standard,
-/obj/item/material/minihoe,
-/obj/item/material/hatchet,
-/obj/item/device/scanner/plant,
-/obj/item/shovel/spade,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/clothing/accessory/armband/hydro,
+/obj/machinery/biogenerator,
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "avM" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
+/obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "avN" = (
@@ -12947,6 +12954,7 @@
 	c_tag = "Kitchen Backroom"
 	},
 /obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "awf" = (
@@ -13252,8 +13260,7 @@
 /area/engineering/lobby)
 "awL" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
@@ -13353,6 +13360,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "awV" = (
@@ -13496,6 +13504,7 @@
 	dir = 4
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "axr" = (
@@ -14194,8 +14203,7 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/computer/modular/preset/nervacommand{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -14539,6 +14547,9 @@
 	codes = list("patrol" = 1, "next_patrol" = "Bridge Starboard");
 	location = "Bar"
 	},
+/mob/living/carbon/human/monkey/punpun{
+	real_name = "Pun Pun"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/civilian/bar)
 "azx" = (
@@ -14554,6 +14565,7 @@
 /area/civilian/bar)
 "azz" = (
 /obj/structure/table/woodentable/walnut,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/carpet/green,
 /area/command/meeting)
 "azA" = (
@@ -14748,7 +14760,6 @@
 "azP" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	frequency = 1379;
-	icon_state = "door_closed";
 	id_tag = "engine_airlock_exterior";
 	locked = 0;
 	name = "Engine Access Interior"
@@ -14808,7 +14819,6 @@
 /area/engineering/lobby)
 "azT" = (
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Engine Access Exterior"
@@ -15170,13 +15180,13 @@
 /turf/simulated/floor/carpet/green,
 /area/command/meeting)
 "aAy" = (
-/obj/machinery/vending/cola{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	icon_state = "alarm0";
 	pixel_x = 22
+	},
+/obj/random/vendor/urist{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/command/meeting)
@@ -15210,8 +15220,7 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/computer/modular/preset/nervacommand{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/command/bridge)
@@ -15345,7 +15354,6 @@
 "aAO" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	frequency = 1379;
-	icon_state = "door_closed";
 	id_tag = "engine_airlock_exterior";
 	locked = 0;
 	name = "Engine Airlock Interior"
@@ -15373,7 +15381,6 @@
 /area/engineering/lobby)
 "aAS" = (
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Engine Access Exterior"
@@ -15527,7 +15534,10 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/third_deck/central)
 "aBg" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/walllocker{
+	pixel_y = 32
+	},
+/obj/structure/largecrate/animal/chick,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/central)
 "aBh" = (
@@ -15535,6 +15545,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers,
 /obj/floor_decal/industrial/warning/full,
 /obj/structure/disposalpipe/up,
+/obj/structure/closet/crate/hydroponics/beekeeping,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/central)
 "aBi" = (
@@ -15548,7 +15559,7 @@
 	pixel_x = 0;
 	pixel_y = 24
 	},
-/obj/structure/largecrate/animal/chick,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/third_deck/central)
 "aBj" = (
@@ -15886,11 +15897,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/lobby)
 "aBV" = (
-/obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "body_scanner_0"
-	},
 /obj/machinery/light,
+/obj/machinery/cryopod{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo1)
 "aBW" = (
@@ -16149,7 +16159,12 @@
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
 "aCp" = (
-/obj/machinery/biogenerator,
+/obj/structure/table/standard,
+/obj/item/material/minihoe,
+/obj/item/material/hatchet,
+/obj/item/device/scanner/plant,
+/obj/item/shovel/spade,
+/obj/item/clothing/accessory/armband/hydro,
 /obj/floor_decal/corner/green/full,
 /turf/simulated/floor/tiled,
 /area/civilian/hydro)
@@ -16238,10 +16253,10 @@
 /obj/floor_decal/corner/green/diagonal,
 /obj/machinery/light,
 /obj/structure/table/standard,
-/obj/item/reagent_containers/food/condiment/flour,
 /obj/machinery/cooker/candy{
 	pixel_y = 13
 	},
+/obj/item/reagent_containers/food/condiment/flour,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "aCz" = (
@@ -20469,8 +20484,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/modular/preset/nervasupply{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -21571,17 +21585,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aLN" = (
-/obj/machinery/computer/modular/preset/engineering{
-	autorun_program = /datum/computer_file/program/supermatter_monitor;
-	dir = 2;
-	icon_state = "console"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/floor_decal/corner/yellow/three_quarters{
 	dir = 1
 	},
+/obj/machinery/computer/modular/preset/engineering,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aLO" = (
@@ -21988,9 +21998,6 @@
 "aMv" = (
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/steel/fifty,
-/obj/item/stack/rods{
-	amount = 60
-	},
 /obj/structure/table/rack,
 /obj/machinery/alarm{
 	dir = 4;
@@ -21999,6 +22006,7 @@
 	},
 /obj/floor_decal/corner/fadeblue/full,
 /obj/floor_decal/industrial/outline/blue,
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled/dark,
 /area/command/eva)
 "aMw" = (
@@ -22281,7 +22289,9 @@
 /turf/simulated/floor/plating,
 /area/security/starboardgun)
 "aMR" = (
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -24706,14 +24716,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
 "aQK" = (
-/obj/machinery/computer/modular/preset/engineering{
-	autorun_program = /datum/computer_file/program/alarm_monitor;
-	dir = 1;
-	icon_state = "console"
-	},
 /obj/machinery/light,
 /obj/floor_decal/corner/yellow{
 	dir = 10
+	},
+/obj/machinery/computer/modular/preset/engineering{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/smmon)
@@ -25144,8 +25152,12 @@
 	icon_state = "0-4"
 	},
 /obj/item/storage/belt/medical,
-/obj/item/storage/fancy/vials,
-/obj/item/storage/fancy/vials,
+/obj/item/storage/fancy/vials{
+	icon_state = "vialbox0"
+	},
+/obj/item/storage/fancy/vials{
+	icon_state = "vialbox0"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cmo)
 "aRD" = (
@@ -27546,6 +27558,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/floor_decal/corner/green/diagonal,
+/obj/item/material/bell,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "bpF" = (
@@ -27963,13 +27976,12 @@
 	dir = 10;
 	icon_state = "corner_white"
 	},
-/obj/machinery/vending/cola{
-	dir = 1;
-	icon_state = "Cola_Machine"
-	},
 /obj/floor_decal/corner/b_green{
 	dir = 5;
 	icon_state = "corner_white"
+	},
+/obj/random/vendor/urist{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/aft/third_deck)
@@ -28358,6 +28370,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/boardarmoury)
+"fsn" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/reagent_containers/food/drinks/teapot,
+/turf/simulated/floor/wood/walnut,
+/area/civilian/bar)
 "fwf" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -28676,8 +28693,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/modular/preset/nervasupply{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/logistics/mailing)
@@ -29135,6 +29151,7 @@
 	id_tag = "roboprivacy2";
 	name = "Robotics Privacy Shutter"
 	},
+/obj/item/material/bell,
 /turf/simulated/floor/tiled/techmaint,
 /area/logistics/robotics)
 "jPi" = (
@@ -29458,6 +29475,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/material/chopping_board,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "lfC" = (
@@ -30245,6 +30263,11 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/commandstarboard)
+"phH" = (
+/obj/floor_decal/corner/green/full,
+/obj/machinery/beehive,
+/turf/simulated/floor/tiled,
+/area/civilian/hydro)
 "psT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5;
@@ -30674,9 +30697,7 @@
 "spz" = (
 /obj/floor_decal/corner/fadeblue/three_quarters,
 /obj/machinery/computer/modular/preset/aislot/sysadmin{
-	autorun_program = /datum/computer_file/program/email_administration;
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/engineering/tcommsmon)
@@ -31200,6 +31221,7 @@
 	pixel_y = -28
 	},
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "uSe" = (
@@ -31761,6 +31783,7 @@
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/material/bell,
 /turf/simulated/floor/tiled/white,
 /area/civilian/kitchen)
 "xQT" = (
@@ -52911,7 +52934,7 @@ auD
 avJ
 awX
 ayf
-avJ
+phH
 auC
 aBk
 aCm
@@ -59778,7 +59801,7 @@ qlC
 auQ
 awj
 bZk
-axu
+fsn
 awh
 aAt
 mZx

--- a/maps/nerva/nerva-3.dmm
+++ b/maps/nerva/nerva-3.dmm
@@ -669,7 +669,6 @@
 /obj/structure/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Engine Access"
@@ -701,9 +700,11 @@
 /turf/simulated/floor/airless,
 /area/space)
 "bL" = (
-/obj/item/material/shard,
-/turf/simulated/floor/airless,
-/area/space)
+/obj/machinery/computer/modular/preset/medical{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/civilian/counselor)
 "bM" = (
 /obj/item/material/shard{
 	icon_state = "small"
@@ -1134,8 +1135,7 @@
 	dir = 1
 	},
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -1178,7 +1178,9 @@
 /turf/simulated/floor/plating,
 /area/space)
 "cH" = (
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "cI" = (
@@ -1488,8 +1490,7 @@
 /area/engineering/techstorage)
 "dh" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/civilian/cryo2)
@@ -6104,11 +6105,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
 "lE" = (
-/obj/machinery/computer/modular/preset/nervacommand{
-	dir = 8;
-	icon_state = "console"
-	},
 /obj/item/card/id/captains_spare,
+/obj/machinery/computer/modular/preset/nervacommand{
+	dir = 8
+	},
 /turf/simulated/floor/wood/walnut,
 /area/command/captain)
 "lF" = (
@@ -6943,7 +6943,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /obj/machinery/door/airlock/hatch/maintenance{
-	icon_state = "door_closed";
 	id_tag = null;
 	locked = 0;
 	name = "Engine Access"
@@ -7089,6 +7088,7 @@
 	icon_state = "alarm0";
 	pixel_y = -22
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/carpet/blue2,
 /area/civilian/dorms)
 "nR" = (
@@ -11100,6 +11100,7 @@
 	icon_state = "corner_white";
 	dir = 10
 	},
+/obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled,
 /area/logistics/primtool)
 "uZ" = (
@@ -12093,7 +12094,9 @@
 "xh" = (
 /obj/machinery/light,
 /obj/floor_decal/corner/paleblue/diagonal,
-/obj/machinery/vending/lavatory,
+/obj/machinery/vending/lavatory{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/civilian/personal)
 "xi" = (
@@ -13717,7 +13720,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/fore/second_deck)
 "Bm" = (
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /turf/simulated/floor/plating,
 /area/civilian/observatory)
 "Bt" = (
@@ -13738,6 +13743,7 @@
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
+/obj/item/spirit_board,
 /turf/simulated/floor/carpet,
 /area/chapel/office)
 "BC" = (
@@ -14682,7 +14688,9 @@
 /obj/structure/closet/secure_closet/psychologist,
 /obj/item/storage/pill_bottle/methylphenidate,
 /obj/item/storage/pill_bottle/citalopram,
-/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/syringe{
+	icon_state = "rg0"
+	},
 /obj/item/reagent_containers/glass/bottle/soporific,
 /obj/item/reagent_containers/pill/paroxetine,
 /obj/item/clothing/mask/smokable/pipe,
@@ -38538,7 +38546,7 @@ aE
 aV
 BZ
 WL
-WL
+bL
 Df
 Wc
 BZ
@@ -41765,7 +41773,7 @@ AX
 bE
 ap
 bD
-bL
+bM
 cf
 cf
 Um

--- a/maps/nerva/nerva-4.dmm
+++ b/maps/nerva/nerva-4.dmm
@@ -1456,7 +1456,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /turf/simulated/floor/plating,
 /area/civilian/abandonedwarehouse)
 "di" = (
@@ -5179,8 +5181,7 @@
 "ka" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/modular/preset/civilian{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5194,8 +5195,7 @@
 "kc" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/modular/preset/aislot/research{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/command/aicore)
@@ -5514,7 +5514,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
 "kG" = (
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /obj/item/hammer/smithing,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)
@@ -5917,7 +5919,9 @@
 /area/maintenance/first_deck/central)
 "ll" = (
 /obj/decal/cleanable/blood,
-/obj/item/material/shard,
+/obj/item/material/shard{
+	icon_state = "small"
+	},
 /mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/plating,
 /area/maintenance/first_deck/central)

--- a/maps/nerva/nerva-5.dmm
+++ b/maps/nerva/nerva-5.dmm
@@ -410,15 +410,18 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = -1;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 4;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 9
+	pixel_y = 9;
+	icon_state = "rg0"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3027,7 +3030,6 @@
 "fy" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuebridge";
 	name = "Window Shutters Control";
 	pixel_y = -4;
@@ -3131,7 +3133,6 @@
 /area/rescue_base/start)
 "fL" = (
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescuedock";
 	name = "Window Shutters Control";
 	pixel_x = 24;
@@ -3146,8 +3147,8 @@
 /area/rescue_base/start)
 "fM" = (
 /obj/machinery/computer/modular/preset/medical{
-	dir = 4;
-	icon_state = "console"
+	autorun_program = /datum/computer_file/program/suit_sensors;
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3156,8 +3157,8 @@
 /area/rescue_base/start)
 "fO" = (
 /obj/machinery/computer/modular/preset/engineering{
-	dir = 8;
-	icon_state = "console"
+	autorun_program = /datum/computer_file/program/alarm_monitor;
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3185,8 +3186,8 @@
 /area/rescue_base/start)
 "fR" = (
 /obj/machinery/computer/modular/preset/security{
-	dir = 8;
-	icon_state = "console"
+	autorun_program = /datum/computer_file/program/forceauthorization;
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rescue_base/start)
@@ -3441,7 +3442,6 @@
 /obj/item/tank/jetpack/carbondioxide,
 /obj/item/tank/jetpack/carbondioxide,
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescueeva";
 	name = "Window Shutters Control";
 	pixel_x = 24;
@@ -3643,9 +3643,15 @@
 	pixel_x = 4;
 	pixel_y = 7
 	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
 /obj/item/reagent_containers/ivbag/blood/human/oneg,
 /obj/item/reagent_containers/ivbag/blood/human/oneg,
 /turf/simulated/floor/tiled/white,
@@ -3785,7 +3791,6 @@
 	},
 /obj/structure/iv_stand,
 /obj/machinery/button/blast_door{
-	icon_state = "doorctrl0";
 	id_tag = "rescueinfirm";
 	name = "Window Shutters Control";
 	pixel_x = 24;
@@ -6845,7 +6850,6 @@
 "pi" = (
 /obj/machinery/door/airlock/hatch{
 	frequency = 1331;
-	icon_state = "door_closed";
 	id_tag = "vox_northwest_lock";
 	locked = 0;
 	req_access = list("ACCESS_SYNDICATE");
@@ -7343,7 +7347,6 @@
 "qw" = (
 /obj/machinery/door/airlock/hatch{
 	frequency = 1331;
-	icon_state = "door_closed";
 	id_tag = "vox_southwest_lock";
 	locked = 0;
 	req_access = list("ACCESS_SYNDICATE");
@@ -9935,8 +9938,8 @@
 "yc" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/computer/modular/preset/security{
-	dir = 1;
-	icon_state = "console"
+	autorun_program = /datum/computer_file/program/forceauthorization;
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -12516,19 +12519,16 @@
 /obj/item/card/id{
 	access = list(201);
 	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
 	name = "Visitor's Card - Merchant's Station"
 	},
 /obj/item/card/id{
 	access = list(201);
 	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
 	name = "Visitor's Card - Merchant's Station"
 	},
 /obj/item/card/id{
 	access = list(201);
 	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
 	name = "Visitor's Card - Merchant's Station"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12928,12 +12928,11 @@
 	},
 /area/map_template/wizard_station)
 "EV" = (
-/obj/machinery/computer/modular/preset/civilian{
-	dir = 1;
-	icon_state = "console"
-	},
 /obj/floor_decal/corner/black/border{
 	dir = 9
+	},
+/obj/machinery/computer/modular/preset/civilian{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/ninja_dojo/dojo)
@@ -13027,15 +13026,18 @@
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = -1;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 4;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 9
+	pixel_y = 9;
+	icon_state = "rg0"
 	},
 /turf/unsimulated/floor{
 	icon_state = "lino"
@@ -13202,7 +13204,6 @@
 "Fw" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1331;
-	icon_state = "door_closed";
 	id_tag = "synd_outer";
 	locked = 0;
 	name = "Ship External Access";
@@ -14624,15 +14625,18 @@
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = -1;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 4;
+	icon_state = "rg0"
 	},
 /obj/item/reagent_containers/syringe/drugs{
 	pixel_x = 3;
-	pixel_y = 9
+	pixel_y = 9;
+	icon_state = "rg0"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -15323,9 +15327,15 @@
 	req_access = list("ACCESS_SYNDICATE")
 	},
 /obj/item/bodybag,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	icon_state = "rg0"
+	},
 /obj/item/reagent_containers/glass/bottle/dylovene{
 	pixel_x = -4;
 	pixel_y = 8


### PR DESCRIPTION
### **Fixes:**
_Broken Icons for the following:_

- Syringes
- Vial Boxes.
- Glass Shards
- Airlock Maintenance Hatches
- Blast Door Buttons
- Steel Rods
- Scalpels

- Modular Computers - (All current presets on every Nerva Z-Level
- Bodyscanner
- Bodyscanner Console
- Cryosleeper

### **Additions:**

#### Random Spawners

- Adds random/stickynotes spawner to a few areas: Medbay, Chef, Science, Bridge, Dormitory, etc.
- Adds a 3-4 bay random vendors, Deck 2 Elevator, Deck 1 Hangar Elevator, etc. - These don't replace anything crucial.
- Flips Bathroom Lavatory Vendor to face correct way.

#### Security & Command Departments

- Adds Ballistic Goggles to the Nerva Armory and Boarding Armory - (3 Pairs in Total, from recent bay pr)

#### Service Departments

- Adds chopping block to Chef's Kitchen so they can combine food.
- Adds plastic curtains to butchery area of kitchen freezer.
- Adds ringable bells: Robotics Window, Holodeck Service Area (Kitchen), Bar to Kitchen Window.
- Bartender's table now has a rag.
- Bar has a teapot.
- Adds Pun Pun back to the Nerva Bar.
- Adds a single apiary to Botanical
- Adds beekeeping equipment to Botanical Maintenance.
- Moves Bioregenerator to the top of Botany instead of by the Vendors to be more useful.
- Adds some tables under objects that should have them. (Freezer Room, Keg, etc.)
- Removes additional space beer keg to give Chef slightly more room in Freezer.
- Adds spirit board to Chaplain's Closet.


Could have missed other stuff, this is a PR over a few days.
