### PR TITLE
Iconmines Part 2 + Bluespace Interlude + Abandoned Hotel

### DIFF
--- a/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
@@ -128,6 +128,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue,
 /area/abandoned_hotel/buffet)
 "bf" = (
@@ -137,6 +138,17 @@
 /obj/structure/bed,
 /turf/simulated/floor/tiled/old_cargo,
 /area/abandoned_hotel/pool)
+"bl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "bo" = (
 /obj/structure/closet/athletic_mixed,
 /obj/decal/cleanable/dirt,
@@ -157,6 +169,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "bw" = (
@@ -233,6 +246,7 @@
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 25
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "bW" = (
@@ -315,9 +329,30 @@
 /obj/structure/table,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/lobby)
+"dj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "dl" = (
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/lobby)
+"dn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "dv" = (
 /obj/floor_decal/corner/black/diagonal,
 /obj/decal/cleanable/dirt,
@@ -325,6 +360,7 @@
 /area/abandoned_hotel/kitchen)
 "dQ" = (
 /obj/structure/ironing_board/fancy,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "dZ" = (
@@ -358,6 +394,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet,
 /area/abandoned_hotel/lobby)
 "ef" = (
@@ -448,6 +485,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
 "eS" = (
@@ -483,6 +521,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "fr" = (
@@ -538,7 +577,12 @@
 "fN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
+/area/abandoned_hotel/lobby)
+"fQ" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "gb" = (
 /obj/floor_decal/corner/pink/diagonal,
@@ -564,6 +608,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
+"gd" = (
+/obj/machinery/door/unpowered/simple/ebony,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden/crude,
+/turf/simulated/floor/wood,
+/area/abandoned_hotel/lobby)
 "gf" = (
 /turf/simulated/floor/tiled/old_tile,
 /area/abandoned_hotel/buffet)
@@ -639,6 +695,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "gR" = (
@@ -985,6 +1042,11 @@
 "jg" = (
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/kitchen)
+"jk" = (
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue3,
+/area/abandoned_hotel/lobby)
 "jl" = (
 /obj/structure/flora/pottedplant/fern,
 /turf/simulated/floor/carpet/green,
@@ -1146,6 +1208,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "mE" = (
@@ -1166,6 +1229,18 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/lobby)
+"mL" = (
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/lobby)
+"mR" = (
+/obj/floor_decal/corner/black/diagonal,
+/obj/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giant_spider/hunter,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/kafel_full,
+/area/abandoned_hotel/kitchen)
 "nd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1252,6 +1327,7 @@
 /area/abandoned_hotel/lobby)
 "nW" = (
 /obj/random/junk,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "oa" = (
@@ -1357,6 +1433,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "pk" = (
@@ -1369,6 +1446,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/buffet)
+"pm" = (
+/obj/machinery/washing_machine,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/freezer,
+/area/abandoned_hotel/lobby)
 "pB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1486,6 +1568,7 @@
 	dir = 8
 	},
 /obj/item/lipstick/random,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "qp" = (
@@ -1555,6 +1638,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "rr" = (
@@ -1575,6 +1660,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "rE" = (
@@ -1614,6 +1700,11 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/reception)
+"rZ" = (
+/obj/floor_decal/corner/black/diagonal,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/kafel_full,
+/area/abandoned_hotel/kitchen)
 "sO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1654,6 +1745,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
+"th" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "ti" = (
 /obj/floor_decal/corner/black/diagonal,
 /obj/machinery/light{
@@ -1767,8 +1867,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
+"uK" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood,
+/area/abandoned_hotel/lobby)
 "uY" = (
 /obj/floor_decal/spline/fancy/black,
 /obj/decal/cleanable/dirt,
@@ -1782,6 +1887,10 @@
 /obj/decal/cleanable/dirt,
 /obj/item/storage/box/freezer/blood/human,
 /turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/lobby)
+"vm" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
 /area/abandoned_hotel/lobby)
 "vn" = (
 /obj/structure/cable{
@@ -1882,6 +1991,12 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/abandoned_hotel/buffet)
+"wn" = (
+/obj/floor_decal/corner/black/diagonal,
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/kafel_full,
+/area/abandoned_hotel/kitchen)
 "wp" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -1935,10 +2050,22 @@
 /obj/structure/window/basic/full,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/pool)
+"wX" = (
+/obj/floor_decal/corner/black/diagonal,
+/obj/machinery/cooker/oven,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/kafel_full,
+/area/abandoned_hotel/kitchen)
 "wZ" = (
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/wood/maple,
 /area/abandoned_hotel/pool)
+"xa" = (
+/obj/floor_decal/corner/black/diagonal,
+/obj/structure/table/marble,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/kafel_full,
+/area/abandoned_hotel/kitchen)
 "xi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -1961,6 +2088,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/pool)
+"xJ" = (
+/obj/structure/window/reinforced,
+/obj/floor_decal/spline/fancy/black{
+	dir = 1
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood,
+/area/abandoned_hotel/buffet)
 "xL" = (
 /obj/floor_decal/spline/fancy/black,
 /turf/simulated/floor/wood/walnut,
@@ -2029,6 +2164,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "yX" = (
@@ -2097,6 +2233,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "zJ" = (
@@ -2115,6 +2252,7 @@
 /obj/item/trash/sosjerky,
 /obj/item/trash/proteinbar,
 /obj/item/trash/pluto,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "Ar" = (
@@ -2129,6 +2267,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "AG" = (
@@ -2172,6 +2311,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "Bo" = (
@@ -2247,6 +2387,7 @@
 	dir = 1
 	},
 /obj/structure/coatrack,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
 "Cu" = (
@@ -2347,6 +2488,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/giant_spider,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "DY" = (
@@ -2457,6 +2600,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "FI" = (
@@ -2481,6 +2625,7 @@
 	dir = 8
 	},
 /obj/item/paper/abandoned_hotel/note_5,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "FZ" = (
@@ -2518,6 +2663,7 @@
 /obj/decal/cleanable/cobweb2{
 	dir = 1
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/kafel_full,
 /area/abandoned_hotel/kitchen)
 "Gv" = (
@@ -2553,6 +2699,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue,
 /area/abandoned_hotel/buffet)
 "Hd" = (
@@ -2596,13 +2743,19 @@
 "Hr" = (
 /obj/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/minitree,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
+"Hw" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "HB" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/lobby)
 "HK" = (
@@ -2616,6 +2769,16 @@
 	},
 /turf/simulated/floor/pool,
 /area/abandoned_hotel/pool)
+"Ic" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/giant_spider/hunter,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "Io" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2783,12 +2946,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
+"KC" = (
+/mob/living/simple_animal/hostile/giant_spider/lurker,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood,
+/area/abandoned_hotel/lobby)
 "KE" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "KI" = (
@@ -2836,6 +3005,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/old_cargo,
 /area/abandoned_hotel/pool)
+"Lb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/mob/living/simple_animal/hostile/giant_spider,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/buffet)
 "Ld" = (
 /obj/structure/flora/pottedplant/sticky,
 /turf/simulated/floor/carpet/blue2,
@@ -2864,6 +3040,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
+"Lq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/lobby)
 "Lv" = (
 /obj/structure/table/standard,
 /obj/item/ironing_board/fancy,
@@ -2886,6 +3072,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "LH" = (
@@ -2991,6 +3178,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/lobby)
+"MY" = (
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood,
+/area/abandoned_hotel/lobby)
 "Nd" = (
 /obj/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -3009,6 +3201,7 @@
 /area/abandoned_hotel/pool)
 "Nx" = (
 /obj/structure/closet/emcloset,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue,
 /area/abandoned_hotel/buffet)
 "NM" = (
@@ -3084,6 +3277,13 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor/tiled/freezer,
+/area/abandoned_hotel/lobby)
+"OL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "OO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3214,6 +3414,8 @@
 /turf/simulated/floor/carpet/blue3,
 /area/abandoned_hotel/lobby)
 "QX" = (
+/mob/living/simple_animal/hostile/giant_spider/spitter,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/blue,
 /area/abandoned_hotel/buffet)
 "Rg" = (
@@ -3372,6 +3574,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
+/area/abandoned_hotel/lobby)
+"SL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/giant_spider,
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "SZ" = (
 /obj/structure/window/reinforced{
@@ -3763,6 +3976,7 @@
 	dir = 6
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/lobby)
 "YH" = (
@@ -3778,6 +3992,16 @@
 /area/space)
 "YM" = (
 /turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/lobby)
+"YS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/lobby)
 "YY" = (
 /obj/floor_decal/spline/fancy/black{
@@ -21905,8 +22129,8 @@ kG
 rx
 cv
 eH
-QE
-CB
+jk
+KC
 fN
 cv
 Hh
@@ -22105,11 +22329,11 @@ zp
 CB
 Sm
 kG
-cv
+Fv
 QE
 QE
 RA
-qi
+MY
 cv
 lx
 Pn
@@ -22307,11 +22531,11 @@ DS
 qi
 kG
 kG
-cv
+vm
 Cl
 Hr
 qi
-CB
+uK
 cv
 Eo
 jr
@@ -22501,8 +22725,8 @@ aa
 cv
 cv
 cv
-ur
-fF
+pm
+SL
 kK
 cv
 gM
@@ -22718,7 +22942,7 @@ HB
 FQ
 cv
 bG
-ZK
+fQ
 qb
 hg
 YM
@@ -22911,7 +23135,7 @@ cv
 cv
 cv
 cv
-ep
+gd
 cv
 cv
 cv
@@ -22919,7 +23143,7 @@ ep
 cv
 cv
 cv
-jc
+YS
 ZK
 qb
 io
@@ -23107,17 +23331,17 @@ ZU
 yX
 yX
 ZK
-ZK
-zd
-ZK
+fQ
+Lq
+fQ
 cT
 Qg
 yX
 bq
 yX
-yX
+mL
 FH
-jc
+YS
 nW
 ZK
 ZK
@@ -23320,7 +23544,7 @@ HK
 JF
 AC
 rC
-MG
+OL
 MG
 MG
 nA
@@ -25538,7 +25762,7 @@ em
 DY
 Lk
 Xg
-DD
+th
 Lk
 Ol
 oM
@@ -25739,7 +25963,7 @@ Lk
 eo
 pZ
 Gi
-Zw
+Lb
 DD
 Lk
 cv
@@ -25941,9 +26165,9 @@ Hd
 VV
 wG
 Lk
-Qo
-sO
-eP
+dj
+dn
+xJ
 eV
 qH
 DO
@@ -26145,7 +26369,7 @@ Lk
 Lk
 Qo
 DD
-eP
+xJ
 eX
 gu
 Ms
@@ -27150,12 +27374,12 @@ Mt
 Oz
 cg
 cK
-cK
+wX
 Gu
 yY
 UW
-sO
-eP
+dn
+xJ
 eV
 gu
 Vu
@@ -27352,12 +27576,12 @@ Ru
 dv
 Oz
 Oz
-dv
-dv
+wn
+mR
 yY
-UW
-sO
-eP
+bl
+dn
+xJ
 fD
 ec
 ec
@@ -27555,11 +27779,11 @@ dv
 Oc
 Nd
 Nd
-Oz
+rZ
 yY
-Qo
-sO
-eP
+dj
+dn
+xJ
 eV
 gu
 Vu
@@ -27752,16 +27976,16 @@ vr
 Kr
 yY
 yY
-Nd
+xa
 dv
 Ln
 Nd
 Rg
-dv
+wn
 yY
-Qo
-sO
-eP
+dj
+dn
+xJ
 gc
 gu
 KI
@@ -28161,7 +28385,7 @@ zG
 ti
 eS
 uF
-Oz
+rZ
 Ej
 QX
 sO
@@ -28365,8 +28589,8 @@ yY
 yY
 yY
 yY
-QX
-sO
+Hw
+dn
 eF
 gf
 Sx
@@ -28568,7 +28792,7 @@ hl
 bK
 yY
 ef
-DD
+Ic
 kT
 ae
 gL

--- a/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
@@ -159,6 +159,7 @@
 /area/abandoned_hotel/evac)
 "be" = (
 /obj/item/stack/material/tritium,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
 "bf" = (
@@ -173,6 +174,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "bl" = (
@@ -237,6 +239,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "bI" = (
@@ -372,9 +375,12 @@
 /turf/simulated/floor/wood/maple,
 /area/abandoned_hotel/overlook)
 "di" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 1
+	},
+/obj/decal/cleanable/dirt,
 /obj/spider/stickyweb,
-/mob/living/simple_animal/hostile/giant_spider,
-/turf/simulated/floor/tiled/freezer,
+/turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "dp" = (
 /obj/structure/cable{
@@ -394,6 +400,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/rooms)
+"du" = (
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "dx" = (
@@ -530,6 +541,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "eM" = (
@@ -605,6 +617,8 @@
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "fy" = (
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
 "fC" = (
@@ -874,7 +888,7 @@
 "gY" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
-/mob/living/simple_animal/hostile/giant_spider,
+/mob/living/simple_animal/hostile/giant_spider/guard,
 /turf/simulated/floor/wood,
 /area/abandoned_hotel/rooms)
 "ha" = (
@@ -897,6 +911,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "hy" = (
@@ -1116,6 +1131,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/rooms)
+"jJ" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "jZ" = (
 /obj/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1157,6 +1176,21 @@
 /obj/decal/cleanable/dirt,
 /obj/spider/stickyweb,
 /turf/simulated/floor/tiled/freezer,
+/area/abandoned_hotel/rooms)
+"lh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "li" = (
 /obj/structure/bed/chair/comfy/green{
@@ -1216,6 +1250,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/evac)
 "mb" = (
@@ -1263,6 +1298,11 @@
 "mC" = (
 /obj/random/accessory,
 /turf/simulated/floor/carpet/blue,
+/area/abandoned_hotel/rooms)
+"mK" = (
+/obj/spider/stickyweb,
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/turf/simulated/floor/tiled/freezer,
 /area/abandoned_hotel/rooms)
 "mO" = (
 /obj/decal/cleanable/dirt,
@@ -1374,6 +1414,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "oM" = (
@@ -1382,6 +1423,11 @@
 	icon_state = "railing0-1"
 	},
 /turf/simulated/open,
+/area/abandoned_hotel/rooms)
+"pe" = (
+/obj/item/ammo_casing/pistol/small,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "pq" = (
 /obj/structure/hygiene/shower{
@@ -1569,6 +1615,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
+"ri" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/giant_spider/spitter,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "rr" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1632,6 +1686,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "sH" = (
@@ -1639,6 +1694,7 @@
 	dir = 4
 	},
 /obj/item/ammo_casing/pistol/small,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "sN" = (
@@ -1794,6 +1850,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/abandoned_hotel/overlook)
+"uK" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/abandoned_hotel/solar)
 "uP" = (
 /turf/space,
 /area/abandoned_hotel/evac)
@@ -1907,11 +1967,13 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "wS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/spider/stickyweb,
 /turf/simulated/floor/tiled,
 /area/abandoned_hotel/evac)
 "wW" = (
@@ -1936,12 +1998,35 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
+"xC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/rooms)
 "xL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
+/area/abandoned_hotel/rooms)
+"xP" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
+"xV" = (
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "xZ" = (
 /obj/floor_decal/spline/fancy/black{
@@ -1989,6 +2074,7 @@
 /obj/structure/closet/crate,
 /obj/item/stack/material/tritium,
 /obj/item/stack/material/tritium,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
 "zi" = (
@@ -2032,6 +2118,15 @@
 /obj/structure/window/reinforced/full,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/reinforced,
+/area/abandoned_hotel/rooms)
+"zV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "zX" = (
 /obj/spider/stickyweb,
@@ -2082,6 +2177,13 @@
 	dir = 9
 	},
 /turf/simulated/floor/wood,
+/area/abandoned_hotel/rooms)
+"AT" = (
+/obj/structure/bed/chair/comfy/green{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "AX" = (
 /obj/landmark/map_data{
@@ -2197,6 +2299,21 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
+"CH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/rooms)
 "CK" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -2237,6 +2354,7 @@
 "Ds" = (
 /obj/decal/cleanable/dirt,
 /obj/item/storage/toolbox/mechanical,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
 "DA" = (
@@ -2300,6 +2418,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
 "EN" = (
@@ -2323,6 +2442,7 @@
 	},
 /obj/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/mob/living/simple_animal/hostile/giant_spider/spitter,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "Fm" = (
@@ -2501,6 +2621,11 @@
 /obj/item/frame/fire_alarm,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
+"HQ" = (
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "HV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2571,6 +2696,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/rooms)
+"Kw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/rooms)
 "KH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -2617,6 +2748,10 @@
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/red,
 /area/abandoned_hotel/rooms)
+"LG" = (
+/obj/spider/stickyweb,
+/turf/simulated/floor/tiled,
+/area/abandoned_hotel/evac)
 "LI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -2807,6 +2942,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "OJ" = (
@@ -2834,6 +2970,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/atmos)
+"Pg" = (
+/mob/living/simple_animal/hostile/giant_spider/electric,
+/obj/spider/stickyweb,
+/turf/simulated/floor/plating,
+/area/abandoned_hotel/solar)
 "Pw" = (
 /obj/item/ammo_casing/pistol/small,
 /turf/simulated/floor/wood/walnut,
@@ -2920,6 +3061,14 @@
 /obj/structure/closet/wardrobe,
 /turf/simulated/floor/carpet/red,
 /area/abandoned_hotel/rooms)
+"Rx" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 8
+	},
+/obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "RJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2953,6 +3102,7 @@
 	dir = 4
 	},
 /obj/random/bomb_supply,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "Sr" = (
@@ -2972,8 +3122,15 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/port_gen/pacman/mrs,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
+"SR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/spider/stickyweb,
+/turf/simulated/floor/carpet/green,
+/area/abandoned_hotel/rooms)
 "SX" = (
 /obj/structure/window/basic{
 	dir = 8
@@ -2990,6 +3147,7 @@
 /area/abandoned_hotel/rooms)
 "Tl" = (
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/solar)
 "Tr" = (
@@ -3020,6 +3178,7 @@
 	dir = 4
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "TT" = (
@@ -3069,6 +3228,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/abandoned_hotel/atmos)
+"UO" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "UQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3276,6 +3443,7 @@
 	dir = 8
 	},
 /obj/decal/cleanable/dirt,
+/obj/spider/stickyweb,
 /turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "YE" = (
@@ -3283,11 +3451,23 @@
 /obj/random/contraband,
 /turf/simulated/floor/wood/walnut,
 /area/abandoned_hotel/rooms)
+"YN" = (
+/obj/floor_decal/spline/fancy/black{
+	dir = 1
+	},
+/obj/spider/stickyweb,
+/turf/simulated/floor/wood/walnut,
+/area/abandoned_hotel/rooms)
 "YS" = (
 /obj/structure/table/woodentable/walnut,
 /obj/spider/stickyweb,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/carpet/blue3,
+/area/abandoned_hotel/rooms)
+"YV" = (
+/obj/spider/stickyweb,
+/mob/living/simple_animal/hostile/giant_spider,
+/turf/simulated/floor/carpet/green,
 /area/abandoned_hotel/rooms)
 "Ze" = (
 /turf/simulated/floor/plating,
@@ -22623,10 +22803,10 @@ DA
 WT
 MA
 wQ
-DA
-WT
+zV
+lh
 eJ
-Yu
+du
 sC
 Yu
 Yu
@@ -22821,11 +23001,11 @@ ZE
 bM
 Fq
 Oi
-iu
+xC
 TP
 zY
 Lj
-zY
+SR
 TP
 YC
 hu
@@ -23446,8 +23626,8 @@ yV
 HE
 HE
 fa
-fa
-HE
+UO
+Rx
 fa
 Pw
 ij
@@ -23648,11 +23828,11 @@ kM
 sq
 sq
 EM
-sq
+xP
 sH
 EM
-Ri
-ij
+HQ
+jJ
 rT
 zL
 aa
@@ -23853,8 +24033,8 @@ bJ
 bJ
 bJ
 qW
-kM
-Pw
+YN
+pe
 Uq
 Uq
 aa
@@ -24055,8 +24235,8 @@ Gb
 Gb
 Gb
 EF
-kM
-mT
+ri
+AT
 Uo
 aa
 aa
@@ -24257,7 +24437,7 @@ Gb
 Gb
 Gb
 EF
-Qr
+di
 Vv
 Uo
 aa
@@ -24459,7 +24639,7 @@ Gb
 Gb
 Gb
 EF
-kM
+YN
 MT
 Uo
 aa
@@ -26869,7 +27049,7 @@ mh
 mh
 dz
 dF
-Zg
+xV
 Uq
 Uq
 Uq
@@ -27070,8 +27250,8 @@ sW
 sW
 Xa
 Uq
-pK
-Yu
+CH
+YV
 Uq
 sA
 UZ
@@ -27273,7 +27453,7 @@ fS
 SZ
 Uq
 oE
-ip
+Kw
 hN
 KP
 AY
@@ -27672,7 +27852,7 @@ dC
 dC
 dC
 ze
-fy
+uK
 fy
 Ds
 dC
@@ -27876,9 +28056,9 @@ dC
 SL
 Db
 be
-fy
+uK
 dC
-pK
+CH
 Yu
 Uq
 tZ
@@ -28076,12 +28256,12 @@ dC
 dC
 dC
 xy
-fy
+Pg
 Tl
 gb
 pY
 OC
-Yu
+du
 Uq
 Uq
 Uq
@@ -28282,11 +28462,11 @@ PH
 Av
 kw
 dC
-pK
-Zg
+CH
+xV
 Uq
 tm
-zX
+mK
 zX
 zX
 Uq
@@ -28484,11 +28664,11 @@ GV
 uZ
 qI
 dC
-pK
+CH
 Zg
 Uq
 CZ
-di
+zX
 cL
 Vr
 Uq
@@ -28889,7 +29069,7 @@ Op
 qw
 gy
 mb
-Yp
+LG
 lX
 cd
 Np

--- a/maps/away/glloyd_jungle/glloyd_jungle.dmm
+++ b/maps/away/glloyd_jungle/glloyd_jungle.dmm
@@ -906,7 +906,7 @@
 /turf/simulated/floor/plating,
 /area/planet/jungle/away)
 "df" = (
-/obj/item/stack/rods,
+/obj/item/stack/material/rods,
 /turf/simulated/floor/plating,
 /area/planet/jungle/away)
 "dg" = (
@@ -1169,9 +1169,7 @@
 /obj/item/stack/material/plasteel{
 	amount = 10
 	},
-/obj/item/stack/rods{
-	amount = 50
-	},
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled,
 /area/jungleoutpost/main)
 "dQ" = (
@@ -1307,7 +1305,7 @@
 /turf/simulated/floor/plating,
 /area/jungleoutpost/main)
 "ef" = (
-/obj/item/stack/rods,
+/obj/item/stack/material/rods,
 /turf/simulated/floor/plating,
 /area/jungleoutpost/main)
 "eg" = (
@@ -1547,9 +1545,6 @@
 /turf/simulated/floor/tiled,
 /area/jungleoutpost/main)
 "eA" = (
-/obj/item/stack/rods{
-	amount = 50
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1562,6 +1557,7 @@
 	icon_state = "4-8";
 	pixel_y = 0
 	},
+/obj/item/stack/material/rods,
 /turf/simulated/floor/tiled,
 /area/jungleoutpost/main)
 "eB" = (
@@ -1731,12 +1727,12 @@
 	},
 /area/jungleoutpost/main)
 "eP" = (
-/obj/item/stack/rods,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/stack/material/rods,
 /turf/simulated/floor/plating{
 	icon_state = "dmg1"
 	},
@@ -1971,7 +1967,7 @@
 /turf/simulated/floor/tiled/white,
 /area/jungleoutpost/medbay)
 "fu" = (
-/obj/item/stack/rods,
+/obj/item/stack/material/rods,
 /turf/simulated/floor/plating,
 /area/jungleoutpost/medbay)
 "fv" = (
@@ -2399,10 +2395,8 @@
 /area/jungleoutpost/engi)
 "gw" = (
 /obj/structure/table/standard,
-/obj/item/stack/rods{
-	amount = 50
-	},
 /obj/item/storage/toolbox/mechanical,
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled,
 /area/jungleoutpost/engi)
 "gx" = (
@@ -2481,7 +2475,7 @@
 /turf/simulated/floor/planet/jungle,
 /area/jungleoutpost/engi)
 "gG" = (
-/obj/item/stack/rods,
+/obj/item/stack/material/rods,
 /turf/simulated/floor/planet/jungle,
 /area/planet/jungle/away)
 "gH" = (
@@ -2965,13 +2959,11 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},
@@ -3015,13 +3007,11 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},
@@ -3070,7 +3060,7 @@
 /turf/simulated/floor/plating,
 /area/jungleoutpost/engi)
 "hY" = (
-/obj/item/stack/rods,
+/obj/item/stack/material/rods,
 /turf/simulated/floor/plating,
 /area/jungleoutpost/engi)
 "hZ" = (
@@ -3098,7 +3088,6 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 4;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},
@@ -3142,7 +3131,6 @@
 	},
 /obj/structure/window/reinforced/tinted{
 	dir = 8;
-	icon_state = "twindow";
 	name = "hardened window";
 	opacity = 0
 	},

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -1372,7 +1372,7 @@
 "eA" = (
 /obj/decal/cleanable/dirt,
 /obj/decal/cleanable/dirt,
-/obj/item/scalpel,
+/obj/item/scalpel/basic,
 /turf/simulated/floor/beach/sand,
 /area/icarus/open)
 "eB" = (
@@ -2280,12 +2280,10 @@
 	id_tag = "d1starboardnacelle"
 	},
 /obj/structure/window/boron_reinforced{
-	dir = 8;
-	icon_state = "phoronrwindow"
+	dir = 8
 	},
 /obj/structure/window/boron_reinforced{
-	dir = 1;
-	icon_state = "phoronrwindow"
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -2375,8 +2373,7 @@
 	dir = 4
 	},
 /obj/structure/window/boron_reinforced{
-	dir = 8;
-	icon_state = "phoronrwindow"
+	dir = 8
 	},
 /obj/structure/grille,
 /obj/machinery/door/blast/regular{
@@ -2423,8 +2420,7 @@
 	},
 /obj/structure/window/boron_reinforced,
 /obj/structure/window/boron_reinforced{
-	dir = 8;
-	icon_state = "phoronrwindow"
+	dir = 8
 	},
 /obj/structure/grille,
 /obj/machinery/door/blast/regular{

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -45,7 +45,7 @@
 /obj/structure/magshield/maggen
 	name = "magnetic field generator"
 	desc = "A large three-handed generator with rotating top. It is used to create high-power magnetic fields in hard vacuum."
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 	icon_state = "maggen"
 	anchored = TRUE
 	density = TRUE
@@ -119,14 +119,14 @@
 /obj/structure/magshield/rad_sensor
 	name = "radiation sensor"
 	desc = "Very sensitive vacuum radiation sensor. On top of the metal stand two modified Wilson Cloud Chambers filled with deuterium and tritium water."
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 	icon_state = "rad_sensor"
 	anchored = TRUE
 
 /obj/structure/magshield/nav_light
 	name = "navigation light"
 	desc = "Large and bright light regularly emitting green flashes."
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 	icon_state = "nav_light_green"
 	anchored = TRUE
 	density = TRUE
@@ -146,7 +146,7 @@
 
 /obj/item/book/manual/magshield_manual
 	name = "SOP for Planetary Shield Orbital Station"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 	icon_state = "mg_guide"
 	author = "Terraforms Industrial"
 	title = "Standard operating procedures for Planetary Shield Orbital Station"

--- a/maps/away/magshield/magshield_areas.dm
+++ b/maps/away/magshield/magshield_areas.dm
@@ -4,29 +4,28 @@
 /area/magshield/south
 	name = "Orbital Station South Wing"
 	icon_state = "south"
-	icon = 'magshield_sprites.dmi'
-
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 /area/magshield/north
 	name = "Orbital Station North Wing"
 	icon_state = "north"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 
 /area/magshield/east
 	name = "Orbital Station East Wing"
 	icon_state = "east"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 
 /area/magshield/west
 	name = "Orbital Station West Wing"
 	icon_state = "west"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 
 /area/magshield/engine
 	name = "Orbital Station Engine"
 	icon_state = "engine"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'
 
 /area/magshield/smes_storage
 	name = "Orbital Station SMES Battery Room"
 	icon_state = "smes_storage"
-	icon = 'magshield_sprites.dmi'
+	icon = 'maps/away/magshield/magshield_sprites.dmi'

--- a/maps/bearcat/bearcat-2.dmm
+++ b/maps/bearcat/bearcat-2.dmm
@@ -2276,7 +2276,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0";
+	icon_state = "railing0-1";
 	dir = 8
 	},
 /turf/simulated/open,
@@ -2479,7 +2479,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0";
+	icon_state = "railing0-1";
 	dir = 8
 	},
 /turf/simulated/open,
@@ -2584,7 +2584,7 @@
 	pixel_x = 32
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0";
+	icon_state = "railing0-1";
 	dir = 8
 	},
 /turf/simulated/open,
@@ -2668,7 +2668,7 @@
 	dir = 1
 	},
 /obj/structure/railing/mapped{
-	icon_state = "railing0";
+	icon_state = "railing0-1";
 	dir = 1
 	},
 /obj/machinery/light/spot,
@@ -4045,11 +4045,11 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jJ" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
@@ -4057,7 +4057,7 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jK" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/machinery/meter/turf,
@@ -4068,11 +4068,11 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jL" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -4187,7 +4187,7 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jW" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -4270,7 +4270,7 @@
 /area/ship/scrap/maintenance/engine/aft)
 "ki" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 8
 	},
 /obj/structure/window/boron_reinforced,
@@ -4289,7 +4289,7 @@
 "kk" = (
 /obj/structure/window/boron_reinforced,
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/engine{
@@ -4307,7 +4307,7 @@
 /area/ship/scrap/maintenance/engine/aft)
 "kl" = (
 /obj/structure/window/boron_reinforced{
-	icon_state = "phoronrwindow";
+	icon_state = "rwindow";
 	dir = 1
 	},
 /obj/machinery/atmospherics/binary/pump{

--- a/maps/nerva/nerva.dm
+++ b/maps/nerva/nerva.dm
@@ -80,6 +80,9 @@
 	#include "../away/abandoned_colony/abandoned_colony.dm"
 	#include "../away/meatstation/meatstation.dm"
 	#include "../away/scavver_gantry/scavver_gantry.dm"
+	#include "../away/abandoned_hotel/abandoned_hotel.dm"
+	#include "../bluespace_interlude/bluespace_interlude.dm"
+
 
 	//keep your clothing hacks to yourself
 	// #include "../torch/items/clothing/solgov-accessory.dm"	These don't seem to actually be used, but are causing issues with double-importing

--- a/maps/random_ruins/exoplanet_ruins/crashed_probe/crashed_probe.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_probe/crashed_probe.dmm
@@ -738,7 +738,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/disk,
+/obj/item/disk/data,
 /obj/item/paper/ecprobelog,
 /obj/machinery/computer/dummy{
 	name = "ship intelligence control console"

--- a/maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_1.dmm
+++ b/maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_1.dmm
@@ -19,8 +19,7 @@
 /area/template_noop)
 "e" = (
 /obj/machinery/computer/modular/preset/library{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)

--- a/maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_2.dmm
@@ -22,8 +22,7 @@
 /area/template_noop)
 "e" = (
 /obj/machinery/computer/modular/preset/library{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/template_noop,
 /area/template_noop)

--- a/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dmm
+++ b/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dmm
@@ -9,7 +9,7 @@
 /turf/simulated/floor/fixed/alium,
 /area/template_noop)
 "e" = (
-/obj/structure/fountain/strange,
+/obj/structure/fountain/strange/urist,
 /turf/template_noop,
 /area/template_noop)
 
@@ -44,8 +44,8 @@ a
 b
 c
 a
-e
 a
+e
 c
 b
 "}

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -232,7 +232,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/hydrobase/station/growF)
@@ -349,7 +349,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/hydrobase/station/growF)
@@ -409,7 +409,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/hydrobase/station/growF)
@@ -1001,7 +1001,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/growF)
@@ -1011,7 +1011,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/fixed/alium,
@@ -1022,7 +1022,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/catwalk,
 /obj/random/toolbox,
@@ -1036,7 +1036,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 4
@@ -1558,7 +1558,7 @@
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/cable,
 /obj/structure/catwalk,
@@ -1725,7 +1725,7 @@
 /obj/structure/closet/toolcloset,
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/window/boron_reinforced,
 /obj/structure/catwalk,
@@ -2089,7 +2089,7 @@
 /obj/structure/closet/l3closet/general/multi,
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/processing)
@@ -2128,7 +2128,7 @@
 /obj/structure/catwalk,
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/item/material/shard/phoron,
 /turf/simulated/floor/fixed/alium,
@@ -2152,7 +2152,7 @@
 /obj/structure/catwalk,
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/station/processing)
@@ -2285,7 +2285,7 @@
 /obj/machinery/light,
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/table/rack,
 /obj/item/ammo_casing/shotgun/emp,

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dmm
@@ -55,7 +55,7 @@
 	dir = 1
 	},
 /obj/decal/cleanable/blood,
-/obj/item/gun/projectile/revolver/medium,
+/obj/item/gun/projectile/pistol/magnum_pistol,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/marooned)
 "an" = (

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dmm
@@ -14,15 +14,15 @@
 /obj/machinery/artifact,
 /obj/structure/window/boron_reinforced{
 	dir = 4;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 1;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/window/boron_reinforced{
 	dir = 8;
-	icon_state = "phoronrwindow"
+	icon_state = "rwindow"
 	},
 /obj/structure/window/boron_reinforced,
 /turf/simulated/floor/fixed/alium/ruin,

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -307,8 +307,7 @@
 /area/map_template/oldlab/solars)
 "ev" = (
 /obj/machinery/computer/modular/preset/civilian{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/chem)
@@ -2268,8 +2267,7 @@
 	pixel_y = -6
 	},
 /obj/machinery/computer/modular/preset/civilian{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/xenobio)

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -1257,8 +1257,7 @@
 /area/map_template/oldlab2/lab)
 "gJ" = (
 /obj/machinery/computer/modular/preset/engineering{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -4564,8 +4563,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/modular/preset/security{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/fixedsecurity)
@@ -5291,8 +5289,7 @@
 /area/map_template/oldlab2/server)
 "Ca" = (
 /obj/machinery/computer/modular/preset/security{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/floor_decal/corner/red{
 	dir = 6
@@ -7780,8 +7777,7 @@
 /area/map_template/oldlab2/chem)
 "OM" = (
 /obj/machinery/computer/modular/preset/medical{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/server)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -129,7 +129,8 @@
 	},
 /obj/item/card/id/merchant{
 	desc = "this card can be used to access the Colony's telepad to exchange goods.";
-	name = "trade array access card"
+	name = "trade array access card";
+	icon_state = "base"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/colony/command)

--- a/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dmm
+++ b/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dmm
@@ -73,7 +73,7 @@
 "mg" = (/obj/structure/bed/chair/shuttle/blue{dir = 1; icon_state = "shuttle_chair_preview"},/obj/floor_decal/industrial/outline,/obj/decal/cleanable/dirt,/turf/simulated/floor/tiled/steel_grid,/area/map_template/transshipment/old_snz)
 "mi" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/yellow{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/decal/cleanable/blood/oil,/obj/random/voidhelmet,/turf/simulated/floor/tiled/techfloor/grid,/area/map_template/transshipment/old_snz)
 "mx" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/map_template/transshipment/warehouse)
-"my" = (/obj/machinery/bodyscanner{dir = 4; icon_state = "body_scanner_0"},/obj/machinery/light,/obj/decal/cleanable/dirt,/turf/simulated/floor/tiled/white,/area/map_template/transshipment/old_snz)
+"my" = (/obj/machinery/bodyscanner{dir = 4},/obj/machinery/light,/obj/decal/cleanable/dirt,/turf/simulated/floor/tiled/white,/area/map_template/transshipment/old_snz)
 "mz" = (/obj/machinery/atmospherics/pipe/manifold/visible/cyan,/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/tiled/techfloor/grid,/area/map_template/transshipment/old_snz)
 "mC" = (/obj/decal/cleanable/dirt,/obj/structure/cable{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/exoplanet/concrete,/area/map_template/transshipment/airstrip)
 "mI" = (/obj/decal/cleanable/dirt,/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/exoplanet/concrete,/area/map_template/transshipment/airstrip)

--- a/maps/shipmaps/ship_fastattackcraft_terran.dmm
+++ b/maps/shipmaps/ship_fastattackcraft_terran.dmm
@@ -715,11 +715,9 @@
 /area/boarding_ship)
 "co" = (
 /obj/structure/table/standard,
-/obj/item/stack/rods{
-	amount = 50
-	},
 /obj/item/storage/toolbox/mechanical,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled/techfloor,
 /area/boarding_ship)
 "cp" = (
@@ -731,14 +729,12 @@
 /obj/item/stack/material/steel{
 	amount = 50
 	},
-/obj/item/stack/rods{
-	amount = 50
-	},
 /obj/item/stack/material/glass{
 	amount = 50
 	},
 /obj/item/clothing/gloves/insulated,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/rods/fifty,
 /turf/simulated/floor/tiled/techfloor,
 /area/boarding_ship)
 "cq" = (

--- a/maps/shipmaps/ship_light_freighter.dmm
+++ b/maps/shipmaps/ship_light_freighter.dmm
@@ -1000,7 +1000,7 @@
 "cz" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 1;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)

--- a/maps/shipmaps/ship_pirate_fast1.dmm
+++ b/maps/shipmaps/ship_pirate_fast1.dmm
@@ -90,7 +90,7 @@
 "bL" = (/obj/structure/table/rack,/obj/random/material,/obj/random/powercell,/obj/random/powercell,/obj/random/material,/turf/simulated/floor/tiled/techfloor,/area/boarding_ship)
 "bM" = (/obj/structure/table/rack,/obj/random/toolbox,/obj/random/material,/obj/random/tool,/turf/simulated/floor/tiled/techfloor,/area/boarding_ship)
 "bN" = (/obj/structure/closet/crate/secure/weapon,/obj/item/gun/energy/laser,/obj/item/gun/energy/ionrifle,/obj/item/gun/energy/gun/small,/obj/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techfloor,/area/boarding_ship)
-"bO" = (/obj/structure/table/standard,/obj/item/stack/rods{amount = 50},/obj/item/storage/toolbox/mechanical,/obj/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techfloor,/area/boarding_ship)
+"bO" = (/obj/structure/table/standard,/obj/item/storage/toolbox/mechanical,/obj/floor_decal/industrial/outline/yellow,/obj/item/stack/material/rods/fifty,/turf/simulated/floor/tiled/techfloor,/area/boarding_ship)
 "bP" = (/obj/structure/cryofeed{dir = 4; icon_state = "cryo_rear"},/obj/floor_decal/borderfloorwhite/full,/turf/simulated/floor/tiled/white,/area/boarding_ship)
 "bQ" = (/obj/urist_intangible/triggers/ai_defender_landmark/pirate,/turf/simulated/floor/tiled/techmaint,/area/boarding_ship)
 "bR" = (/turf/simulated/floor/tiled/steel_ridged,/area/boarding_ship)

--- a/maps/shipmaps/ship_pirate_scrapper.dmm
+++ b/maps/shipmaps/ship_pirate_scrapper.dmm
@@ -845,7 +845,7 @@
 "cJ" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1;
-	icon_state = "h2_map"
+	icon_state = "h2"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/boarding_ship)
@@ -965,7 +965,9 @@
 /turf/space,
 /area/boarding_ship)
 "db" = (
-/obj/structure/boarding/self_destruct/pirateship,
+/obj/structure/boarding/self_destruct/pirateship{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/boarding_ship)
 "dj" = (
@@ -1190,8 +1192,7 @@
 /area/boarding_ship)
 "eb" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/boarding_ship)
@@ -1443,7 +1444,7 @@
 "eT" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/boarding_ship)

--- a/maps/shipmaps/ship_pirate_small1.dmm
+++ b/maps/shipmaps/ship_pirate_small1.dmm
@@ -50,7 +50,7 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -219,7 +219,7 @@
 "aC" = (
 /obj/structure/railing/mapped{
 	dir = 1;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -288,10 +288,9 @@
 	dir = 8;
 	icon_state = "tube_map"
 	},
-/obj/structure/cryofeed{
+/obj/machinery/cryopod{
 	dir = 2;
-	icon_state = "body_scanner_1";
-	name = "inert cryogenic freezer"
+	icon_state = "cryopod"
 	},
 /turf/simulated/floor/tiled/white,
 /area/boarding_ship)
@@ -603,7 +602,7 @@
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/random/closet,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -738,7 +737,7 @@
 /obj/machinery/conveyor_switch/oneway,
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1060,7 +1059,7 @@
 "cG" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1072,7 +1071,7 @@
 "cI" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 8;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1557,7 +1556,7 @@
 "dX" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1;
-	icon_state = "h2_map"
+	icon_state = "h2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -2035,11 +2034,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/boarding_ship)
 "fe" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 4;
-	icon_state = "console"
-	},
 /obj/urist_intangible/triggers/station_disk/pirate,
+/obj/machinery/computer/modular/preset/cardslot/command{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/boarding_ship)
 "ff" = (
@@ -2136,7 +2134,9 @@
 /turf/simulated/wall/r_wall/hull,
 /area/boarding_ship)
 "fs" = (
-/obj/structure/boarding/self_destruct/pirateship,
+/obj/structure/boarding/self_destruct/pirateship{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/boarding_ship)
 "ft" = (
@@ -2151,10 +2151,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/boarding_ship)
 "gh" = (
-/obj/structure/cryofeed{
+/obj/machinery/cryopod{
 	dir = 2;
-	icon_state = "body_scanner_1";
-	name = "inert cryogenic freezer"
+	icon_state = "cryopod"
 	},
 /turf/simulated/floor/tiled/white,
 /area/boarding_ship)

--- a/maps/shipmaps/ship_rebel_small1.dmm
+++ b/maps/shipmaps/ship_rebel_small1.dmm
@@ -53,7 +53,7 @@
 	},
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -239,7 +239,7 @@
 "aD" = (
 /obj/structure/railing/mapped{
 	dir = 1;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -667,7 +667,7 @@
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /obj/random/closet,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -835,7 +835,7 @@
 /obj/machinery/conveyor_switch/oneway,
 /obj/structure/railing/mapped{
 	dir = 4;
-	icon_state = "railing0"
+	icon_state = "railing0-1"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1168,7 +1168,7 @@
 "cI" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 4;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1180,7 +1180,7 @@
 "cK" = (
 /obj/machinery/atmospherics/unary/heater{
 	dir = 8;
-	icon_state = "heater_0"
+	icon_state = "heater"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -1724,8 +1724,7 @@
 /area/boarding_ship)
 "dO" = (
 /obj/machinery/computer/modular/preset/library{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/boarding_ship)
@@ -1878,7 +1877,7 @@
 "eh" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1;
-	icon_state = "h2_map"
+	icon_state = "h2"
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/boarding_ship)
@@ -2435,8 +2434,7 @@
 /area/boarding_ship)
 "fs" = (
 /obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 4;
-	icon_state = "console"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/boarding_ship)

--- a/maps/wyrm/templates/refuelingstation.dmm
+++ b/maps/wyrm/templates/refuelingstation.dmm
@@ -139,7 +139,7 @@
 "cI" = (/obj/structure/table/steel,/obj/random/smokes,/obj/item/flame/lighter/random,/obj/structure/cable{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating{color = "#bbbbbb"},/area/away/refueling)
 "cJ" = (/obj/machinery/atmospherics/portables_connector{color = "#bbbbbb"; dir = 4; icon_state = "map_connector"},/obj/floor_decal/industrial/outline/yellow{color = "#d2af6e"},/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating{color = "#bbbbbb"},/area/away/refueling)
 "cK" = (/obj/decal/cleanable/ash,/obj/floor_decal/industrial/warning{color = "#d2af6e"; dir = 4; icon_state = "warning"},/obj/machinery/atmospherics/pipe/manifold/visible{color = "#bbbbbb"},/turf/simulated/floor/plating{color = "#bbbbbb"},/area/away/refueling)
-"cL" = (/obj/floor_decal/industrial/hatch/yellow{color = "#d2af6e"},/obj/machinery/atmospherics/unary/heater{color = "#bbbbbb"; dir = 8; icon_state = "heater_0"},/turf/simulated/floor/plating{color = "#bbbbbb"},/area/away/refueling)
+"cL" = (/obj/floor_decal/industrial/hatch/yellow{color = "#d2af6e"},/obj/machinery/atmospherics/unary/heater{color = "#bbbbbb"; dir = 8; icon_state = "heater"},/turf/simulated/floor/plating{color = "#bbbbbb"},/area/away/refueling)
 "cM" = (/obj/floor_decal/corner/shuttle/yellow/alt{icon_state = "corner_white_shuttle_alt"; dir = 8},/turf/simulated/floor/tiled/dark{color = "#cccccc"},/area/away/refueling)
 "cN" = (/obj/floor_decal/corner/shuttle/fadeblue,/turf/simulated/floor/tiled/dark{color = "#cccccc"},/area/away/refueling)
 "cO" = (/obj/floor_decal/corner/shuttle/fadeblue{icon_state = "corner_white_shuttle"; dir = 10},/turf/simulated/floor/tiled/dark{color = "#cccccc"},/area/away/refueling)


### PR DESCRIPTION
the 8th layer of hell is the icon layer

- Fixes a bunch of icons... all that is left is pretty much the reagent_containers stuff.
This is all the exoplanets, whatever away crap I missed, etc, etc.

- Adds the Abandoned Hotel that bay added about 6 months ago. It only had like 4 spiders, so I made it more dangerous.
- Adds Bluespace Interlude, which can warp you away for a time if you do long-range teleports, etc.